### PR TITLE
feat: recipient transport security indicator in compose

### DIFF
--- a/lib/services/recipient_security_service.dart
+++ b/lib/services/recipient_security_service.dart
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2024-2026 ICD360S e.V.
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import 'dart:io';
+import 'dns_checker.dart';
+import 'logger_service.dart';
+
+enum RecipientSecurityLevel {
+  e2ee,
+  daneTls,
+  tls,
+  plaintext,
+  checking,
+  error,
+}
+
+class RecipientSecurityResult {
+  final RecipientSecurityLevel level;
+  final String label;
+  final String detail;
+
+  const RecipientSecurityResult({
+    required this.level,
+    required this.label,
+    required this.detail,
+  });
+
+  static const checking = RecipientSecurityResult(
+    level: RecipientSecurityLevel.checking,
+    label: 'Checking...',
+    detail: 'Verifying recipient security',
+  );
+}
+
+class RecipientSecurityService {
+  static final Map<String, RecipientSecurityResult> _cache = {};
+  static final Map<String, DateTime> _cacheExpiry = {};
+  static const _cacheDuration = Duration(minutes: 10);
+
+  static Future<RecipientSecurityResult> check(String email) async {
+    final domain = email.split('@').last.toLowerCase();
+
+    final cached = _cache[domain];
+    final expiry = _cacheExpiry[domain];
+    if (cached != null && expiry != null && DateTime.now().isBefore(expiry)) {
+      return cached;
+    }
+
+    try {
+      final result = await _checkDomain(domain);
+      _cache[domain] = result;
+      _cacheExpiry[domain] = DateTime.now().add(_cacheDuration);
+      return result;
+    } catch (ex) {
+      LoggerService.logWarning('RCPT_SEC', 'Check failed for $domain: $ex');
+      return const RecipientSecurityResult(
+        level: RecipientSecurityLevel.error,
+        label: 'Unknown',
+        detail: 'Could not verify recipient security',
+      );
+    }
+  }
+
+  static Future<RecipientSecurityResult> _checkDomain(String domain) async {
+    // Internal domain — always E2EE
+    if (domain == 'icd360s.de') {
+      return const RecipientSecurityResult(
+        level: RecipientSecurityLevel.e2ee,
+        label: 'E2EE',
+        detail: 'End-to-end encrypted (PGP, internal)',
+      );
+    }
+
+    // Check WKD for PGP key
+    // WKD requires HTTPS request which is complex here,
+    // so we skip for now and focus on transport security
+
+    // Check DANE TLSA
+    final mx = await DnsChecker.lookupMx(domain);
+    if (mx.isEmpty) {
+      return const RecipientSecurityResult(
+        level: RecipientSecurityLevel.plaintext,
+        label: 'No MX',
+        detail: 'No mail server found for this domain',
+      );
+    }
+
+    // Extract MX hostname from response (format: "10 mail.example.com.")
+    String mxHost = mx.first;
+    if (mxHost.contains(' ')) {
+      mxHost = mxHost.split(' ').last;
+    }
+    mxHost = mxHost.replaceAll(RegExp(r'\.$'), '');
+
+    // Check DANE TLSA for MX
+    final tlsa = await DnsChecker.lookupTlsa(mxHost);
+    if (tlsa.isNotEmpty) {
+      final dnssec = await DnsChecker.checkDnssec(domain);
+      if (dnssec) {
+        return RecipientSecurityResult(
+          level: RecipientSecurityLevel.daneTls,
+          label: 'DANE+TLS',
+          detail: 'Transport verified via DANE/DNSSEC ($mxHost)',
+        );
+      }
+    }
+
+    // Check if MX supports STARTTLS by attempting connection
+    try {
+      final socket = await Socket.connect(mxHost, 25,
+          timeout: const Duration(seconds: 5));
+      final banner = await socket.transform(
+        const SystemEncoding().decoder).first.timeout(
+        const Duration(seconds: 5));
+      socket.write('EHLO icd360s.de\r\n');
+      await Future.delayed(const Duration(seconds: 1));
+      final response = await socket.transform(
+        const SystemEncoding().decoder).first.timeout(
+        const Duration(seconds: 5));
+      socket.destroy();
+
+      if (response.contains('STARTTLS')) {
+        return RecipientSecurityResult(
+          level: RecipientSecurityLevel.tls,
+          label: 'TLS',
+          detail: 'Transport encrypted (STARTTLS on $mxHost)',
+        );
+      }
+    } catch (_) {
+      // Connection failed or timeout — can't verify TLS
+    }
+
+    // Check MTA-STS as fallback indicator
+    final mtaSts = await DnsChecker.lookupMtaSts(domain);
+    if (mtaSts != null) {
+      return RecipientSecurityResult(
+        level: RecipientSecurityLevel.tls,
+        label: 'MTA-STS',
+        detail: 'Transport policy enforced via MTA-STS ($domain)',
+      );
+    }
+
+    return RecipientSecurityResult(
+      level: RecipientSecurityLevel.plaintext,
+      label: 'Plaintext',
+      detail: 'No TLS verification available for $domain',
+    );
+  }
+}

--- a/lib/views/compose_window.dart
+++ b/lib/views/compose_window.dart
@@ -18,6 +18,7 @@ import '../providers/email_provider.dart';
 import '../services/device_registration_service.dart';
 import '../services/notification_service.dart';
 import '../services/logger_service.dart';
+import '../services/recipient_security_service.dart';
 import '../services/email_history_service.dart';
 import '../services/pgp_key_service.dart';
 import '../services/mtls_service.dart';
@@ -89,6 +90,7 @@ class _ComposeWindowState extends State<ComposeWindow> {
 
   // E2EE: per-recipient PGP key status
   final Map<String, bool> _recipientHasKey = {};
+  final Map<String, RecipientSecurityResult> _recipientSecurity = {};
   bool _encryptionPossible = false;
   Timer? _keyLookupTimer;
 
@@ -554,6 +556,24 @@ class _ComposeWindowState extends State<ComposeWindow> {
     }
   }
 
+
+  /// Check transport security level for all recipients.
+  void _checkRecipientSecurity() {
+    final recipients = _getRecipientsList();
+    for (final email in recipients) {
+      if (email.contains('@') && !_recipientSecurity.containsKey(email)) {
+        _recipientSecurity[email] = RecipientSecurityResult.checking;
+        RecipientSecurityService.check(email).then((result) {
+          if (mounted) {
+            setState(() => _recipientSecurity[email] = result);
+          }
+        });
+      }
+    }
+    // Remove stale entries
+    _recipientSecurity.removeWhere((k, _) => !recipients.contains(k));
+  }
+
   /// Parse recipients from comma-separated string
   List<String> _getRecipientsList() {
     if (_toController.text.isEmpty) return [];
@@ -1012,6 +1032,7 @@ class _ComposeWindowState extends State<ComposeWindow> {
 
                       // E2EE: look up PGP keys for recipients
                       _scheduleKeyLookup();
+                      _checkRecipientSecurity();
                     },
                   ),
                   // E2EE encryption status indicator
@@ -1044,7 +1065,57 @@ class _ComposeWindowState extends State<ComposeWindow> {
                         ],
                       ),
                     ),
-                  // Auto-complete suggestions dropdown
+                  // Transport security indicator per recipient
+                  if (_recipientSecurity.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Wrap(
+                        spacing: 8,
+                        runSpacing: 4,
+                        children: _recipientSecurity.entries.map((entry) {
+                          final email = entry.key;
+                          final sec = entry.value;
+                          final short = email.split('@').last;
+                          Color color;
+                          IconData icon;
+                          switch (sec.level) {
+                            case RecipientSecurityLevel.e2ee:
+                              color = const Color(0xFF107C10);
+                              icon = FluentIcons.lock_solid;
+                            case RecipientSecurityLevel.daneTls:
+                              color = const Color(0xFF0078D4);
+                              icon = FluentIcons.shield_solid;
+                            case RecipientSecurityLevel.tls:
+                              color = const Color(0xFFCA5010);
+                              icon = FluentIcons.shield;
+                            case RecipientSecurityLevel.plaintext:
+                              color = const Color(0xFFD83B01);
+                              icon = FluentIcons.warning;
+                            case RecipientSecurityLevel.checking:
+                              color = Colors.grey;
+                              icon = FluentIcons.sync_icon;
+                            case RecipientSecurityLevel.error:
+                              color = Colors.grey;
+                              icon = FluentIcons.unknown;
+                          }
+                          return Tooltip(
+                            message: sec.detail,
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Icon(icon, size: 10, color: color),
+                                const SizedBox(width: 3),
+                                Text(
+                                  '$short: ${sec.label}',
+                                  style: TextStyle(fontSize: 10, color: color),
+                                ),
+                              ],
+                            ),
+                          );
+                        }).toList(),
+                      ),
+                    ),
+                                    // Auto-complete suggestions dropdown
                   if (_showToSuggestions && _toSuggestions.isNotEmpty)
                     Container(
                       margin: const EdgeInsets.only(top: 4),


### PR DESCRIPTION
## Summary
- New `RecipientSecurityService` — checks recipient domain security level
- Security indicator in compose window shows per-recipient:
  - 🟢 **E2EE** — internal @icd360s.de (PGP encrypted)
  - 🔵 **DANE+TLS** — DANE TLSA + DNSSEC verified transport
  - 🟠 **TLS/MTA-STS** — encrypted transport (opportunistic or MTA-STS)
  - 🔴 **Plaintext** — no TLS verification available
- Checks: MX records, DANE TLSA, DNSSEC AD flag, MTA-STS, STARTTLS
- Results cached 10 min per domain
- Tooltip shows detail (e.g. "Transport verified via DANE/DNSSEC (mail.example.com)")

## Test plan
- [ ] Compose email to @icd360s.de → shows E2EE green
- [ ] Compose email to @gmail.com → shows TLS or DANE+TLS
- [ ] Compose email to unknown domain → shows appropriate level
- [ ] Tooltip shows detail on hover
- [ ] Multiple recipients show individual indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)