### PR TITLE
feat: RFC 9788 header protection for PGP emails

### DIFF
--- a/lib/services/mail_service.dart
+++ b/lib/services/mail_service.dart
@@ -354,6 +354,23 @@ class MailService {
                 }
                 email.body = body ?? decryptedRaw;
                 email.isEncrypted = true;
+                // RFC 9788: extract protected Subject from decrypted payload
+                final subjectMatch = RegExp(
+                  r'^Subject:\s*(.+)$', multiLine: true,
+                ).firstMatch(decryptedRaw);
+                if (subjectMatch != null && (email.subject == '[...]' || email.subject.isEmpty)) {
+                  var protectedSubject = subjectMatch.group(1)!.trim();
+                  // Decode RFC 2047 if needed
+                  if (protectedSubject.startsWith('=?')) {
+                    try {
+                      final m = RegExp(r'=\?([^?]+)\?([BbQq])\?([^?]+)\?=').firstMatch(protectedSubject);
+                      if (m != null && m.group(2)!.toUpperCase() == 'B') {
+                        protectedSubject = utf8.decode(base64.decode(m.group(3)!));
+                      }
+                    } catch (_) {}
+                  }
+                  email.subject = protectedSubject;
+                }
                 LoggerService.log('PGP',
                     '✓ Decrypted E2EE email from ${email.from}');
               } catch (ex) {
@@ -577,7 +594,12 @@ class MailService {
                 : renderedFull;
             final contentType = mimeMessage.getHeaderValue('content-type') ?? '';
             final mimeVersion = mimeMessage.getHeaderValue('mime-version') ?? '1.0';
+            // RFC 9788: include protected Subject inside encrypted payload
+            final encodedSubject = subject.contains(RegExp(r'[^\x20-\x7E]'))
+                ? '=?UTF-8?B?${base64.encode(utf8.encode(subject))}?='
+                : subject;
             final innerMime = 'MIME-Version: $mimeVersion\r\n'
+                'Subject: $encodedSubject\r\n'
                 'Content-Type: $contentType\r\n'
                 '\r\n'
                 '$mimeBody';

--- a/lib/services/pgp_key_service.dart
+++ b/lib/services/pgp_key_service.dart
@@ -667,10 +667,9 @@ class PgpKeyService {
         '✓ Native encryption completed in ${stopwatch.elapsedMilliseconds}ms '
         '(${(utf8.encode(innerMimeBody).length / 1024).round()} KB plaintext)');
 
-    // RFC 2047 encode subject if non-ASCII
-    final encodedSubject = _rfc2047Encode(subject);
-
     // Build outer wrapper with CRLF line endings (RFC 5321)
+    // RFC 9788: outer Subject is obscured; real Subject is inside
+    // the encrypted payload so only the recipient can read it.
     final boundary = 'pgp-${DateTime.now().millisecondsSinceEpoch}';
     final buf = StringBuffer()
       ..write('MIME-Version: 1.0\r\n')
@@ -681,7 +680,7 @@ class PgpKeyService {
     if (cc.isNotEmpty) buf.write('Cc: $cc\r\n');
     // BCC intentionally omitted — SMTP envelope handles delivery
     buf
-      ..write('Subject: $encodedSubject\r\n')
+      ..write('Subject: [...]\r\n')
       ..write('Content-Type: multipart/encrypted;\r\n')
       ..write('\tprotocol="application/pgp-encrypted";\r\n')
       ..write('\tboundary="$boundary"\r\n')


### PR DESCRIPTION
## Summary
- Outer Subject replaced with `[...]` on encrypted PGP/MIME emails
- Real Subject moved inside encrypted payload (RFC 9788)
- Decryption extracts protected Subject for display
- Server-side `pgp-mime-encrypt.py` also updated

## Test plan
- [ ] Send encrypted email between two icd360s.de accounts
- [ ] Verify outer Subject shows `[...]` in Maildir/logs
- [ ] Verify recipient sees real Subject after decryption