### PR TITLE
fix(cert): auto-refresh cached mTLS cert when <7d remain

### DIFF
--- a/lib/providers/email_provider.dart
+++ b/lib/providers/email_provider.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import '../models/models.dart';
 import '../services/services.dart';
 import 'dart:io' show Platform;
+import '../services/certificate_expiry_monitor.dart';
 import '../services/device_approval_service.dart';
 import '../services/device_registration_service.dart';
 import '../services/pgp_key_service.dart';
@@ -249,9 +250,23 @@ class EmailProvider with ChangeNotifier {
     final restored =
         await CertificateService.restoreFromSecureStorageFor(account.username);
     if (restored) {
-      LoggerService.log('PROVIDER',
-          '✓ Cert for ${account.username} restored from secure storage');
-      return true;
+      // Don't trust the cache blindly — if the cached cert is expired or
+      // about to expire (<7 days), fall through to the re-approval path
+      // so we get a fresh one. Otherwise the app silently uses an expired
+      // cert and HAProxy rejects the mTLS handshake = infinite spinner
+      // with no actionable error (incident: 2026-05-15, affected all users
+      // whose 90d certs lapsed the same day).
+      final daysLeft = CertificateExpiryMonitor.getDaysUntilExpiry();
+      if (daysLeft != null && daysLeft < 7) {
+        LoggerService.logWarning('PROVIDER',
+            'Cached cert for ${account.username} expires in $daysLeft days — '
+            'discarding cache and re-requesting');
+        await CertificateService.clearCertificatesFor(account.username);
+      } else {
+        LoggerService.log('PROVIDER',
+            '✓ Cert for ${account.username} restored from secure storage');
+        return true;
+      }
     }
 
     // No cert in secure storage — request Faza 3 re-approval.


### PR DESCRIPTION
## Summary

- App was silently using cached mTLS certs without checking expiry → HAProxy rejected the handshake when the cert lapsed → infinite spinner with no actionable error
- Now `_ensureCertForAccount` checks `CertificateExpiryMonitor.getDaysUntilExpiry()` after restoring from secure storage; if <7 days remain, wipes the cache and falls through to the Faza 3 re-approval path (auto-approved for same-device since the server-side fix today)
- Direct fix for the 2026-05-15 outage where 31/61 user certs all expired the same evening

## Test plan
- [ ] Login with cached cert that has >7 days left → cache restore path taken, no network call
- [ ] Login with cached cert that has <7 days left → cache discarded, Faza 3 request submitted, server auto-approves (same-device), fresh cert downloaded
- [ ] Login with cached cert already expired → same as above (negative daysLeft also satisfies <7)
- [ ] flutter analyze clean
- [ ] Manual smoke: redeschide app dupa expirare → mailurile apar in <10s

Note: depends on server-side same-device auto-approve being enabled in request-access.php (deployed 2026-05-16). Without it, this fix would still fall through to admin-approval queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)