### PR TITLE
refactor: envelope-first IMAP fetch + on-demand body load (-99% RAM/refresh)

### DIFF
--- a/lib/models/email.dart
+++ b/lib/models/email.dart
@@ -11,13 +11,29 @@ class Email {
   String cc;  // Carbon Copy recipients (visible when receiving)
   String subject;
   DateTime date;
-  String body;
+  /// Email body. `null` means "not yet loaded" (envelope-only fetch).
+  /// Set by [EmailProvider.loadBody] when the user opens the email viewer.
+  String? body;
   bool isRead;
   String threatLevel;
   int threatScore;
   String threatDetails;
   int? uid; // IMAP UID for reliable operations
   bool isEncrypted; // E2EE: decrypted from PGP
+
+  /// Total message size in bytes as reported by IMAP RFC822.SIZE
+  /// (envelope fetch). Used to decide whether to download the full
+  /// body inline or warn the user about a large download.
+  int? bodySize;
+
+  /// True when [body] is non-null. False right after an envelope-only
+  /// fetch, until [EmailProvider.loadBody] populates the body.
+  bool get bodyLoaded => body != null;
+
+  /// True when the server message exceeded the body-fetch cap and only
+  /// a truncated version was loaded. UI can show a "tap to download
+  /// full message" affordance.
+  bool bodyTruncated;
 
   // Attachments
   List<EmailAttachment> attachments;
@@ -32,13 +48,15 @@ class Email {
     this.cc = '',
     this.subject = '',
     DateTime? date,
-    this.body = '',
+    this.body,
     this.isRead = false,
     this.threatLevel = 'Safe',
     this.threatScore = 0,
     this.threatDetails = '',
     this.uid,
     this.isEncrypted = false,
+    this.bodySize,
+    this.bodyTruncated = false,
     List<EmailAttachment>? attachments,
     Map<String, String>? headers,
   })  : date = date ?? DateTime.now(),
@@ -55,6 +73,8 @@ class Email {
       'subject': subject,
       'date': date.toIso8601String(),
       'body': body,
+      'bodySize': bodySize,
+      'bodyTruncated': bodyTruncated,
       'isRead': isRead,
       'threatLevel': threatLevel,
       'threatScore': threatScore,
@@ -75,7 +95,9 @@ class Email {
       date: json['date'] != null
           ? DateTime.parse(json['date'] as String)
           : DateTime.now(),
-      body: json['body'] as String? ?? '',
+      body: json['body'] as String?,
+      bodySize: json['bodySize'] as int?,
+      bodyTruncated: json['bodyTruncated'] as bool? ?? false,
       isRead: json['isRead'] as bool? ?? false,
       threatLevel: json['threatLevel'] as String? ?? 'Safe',
       threatScore: json['threatScore'] as int? ?? 0,
@@ -100,6 +122,8 @@ class Email {
     String? subject,
     DateTime? date,
     String? body,
+    int? bodySize,
+    bool? bodyTruncated,
     bool? isRead,
     String? threatLevel,
     int? threatScore,
@@ -115,6 +139,8 @@ class Email {
       subject: subject ?? this.subject,
       date: date ?? this.date,
       body: body ?? this.body,
+      bodySize: bodySize ?? this.bodySize,
+      bodyTruncated: bodyTruncated ?? this.bodyTruncated,
       isRead: isRead ?? this.isRead,
       threatLevel: threatLevel ?? this.threatLevel,
       threatScore: threatScore ?? this.threatScore,

--- a/lib/providers/email_provider.dart
+++ b/lib/providers/email_provider.dart
@@ -66,11 +66,18 @@ class EmailProvider with ChangeNotifier {
   /// where 60s auto-refresh leaked 300MB/cycle until first wipe was added.
   static void _wipeBodies(Iterable<Email> emails) {
     for (final email in emails) {
-      email.body = '';
+      // Reset body to null so bodyLoaded → false. Reopening the email
+      // triggers another fetchFullBody from server. With envelope-first
+      // fetch, most emails already have body == null and this is a no-op.
+      email.body = null;
+      email.bodyTruncated = false;
       email.threatDetails = '';
       for (final a in email.attachments) {
         a.data = null;
       }
+      // Drop attachment metadata too — they were populated by the body
+      // fetch path and will be repopulated on next loadBody.
+      email.attachments.clear();
     }
   }
   ServerHealthStatus? _serverHealth;
@@ -1150,6 +1157,37 @@ class EmailProvider with ChangeNotifier {
       }
     } catch (ex, stackTrace) {
       LoggerService.logError('PROVIDER', ex, stackTrace);
+    }
+  }
+
+  /// Load the full body for [email] (on-demand body fetch).
+  ///
+  /// The list/refresh path fetches envelopes only (no bodies). When the
+  /// user opens the email viewer, this method is called to download the
+  /// MIME body, decrypt PGP/MIME if applicable, and extract attachments.
+  /// On success, [Email.body] becomes non-null and listeners are notified
+  /// so the viewer rebuilds with the content.
+  ///
+  /// Idempotent: if `email.bodyLoaded` is already true, this is a no-op.
+  Future<void> loadBody(Email email) async {
+    if (email.bodyLoaded) return;
+    final account = _currentAccount;
+    if (account == null) {
+      LoggerService.logWarning(
+          'PROVIDER', 'loadBody called with no current account');
+      return;
+    }
+    try {
+      await _mailService.fetchFullBody(account, email, folder: _currentFolder);
+      LoggerService.log('PROVIDER',
+          '✓ Loaded body for ${email.messageId} (${email.body?.length ?? 0} chars, '
+          '${email.attachments.length} attachments, '
+          'encrypted=${email.isEncrypted}, truncated=${email.bodyTruncated})');
+    } catch (ex, stackTrace) {
+      // fetchFullBody already populated email.body with an error sentinel.
+      LoggerService.logError('PROVIDER', ex, stackTrace);
+    } finally {
+      if (!_disposed) notifyListeners();
     }
   }
 

--- a/lib/services/mail_service.dart
+++ b/lib/services/mail_service.dart
@@ -198,7 +198,18 @@ class MailService {
     }
   }
 
-  /// Fetch emails from a folder via IMAP (uses connection pool)
+  /// Fetch email envelopes (no bodies) for a folder.
+  ///
+  /// ARCHITECTURE: Envelope-first fetch. Returns metadata only —
+  /// subject, from/to/cc, date, message-id, flags, and RFC822.SIZE.
+  /// Bodies are loaded on demand by [fetchFullBody] when the user
+  /// opens the email viewer.
+  ///
+  /// MEMORY: Each envelope is ~1-3 KB. A 51-message INBOX uses
+  /// ~150 KB instead of the previous ~300 MB (with bodies up to
+  /// 8 MB SEIPD ciphertext each). PGP inspection has been removed
+  /// from this hot path — it now runs only inside [fetchFullBody]
+  /// when the user actually opens an encrypted email.
   Future<List<Email>> fetchEmailsAsync(
     EmailAccount account,
     String folder,
@@ -219,185 +230,58 @@ class MailService {
           return emails;
         }
 
-        // Fetch last 50 emails
-        // IMPORTANT: Include UID in criteria so message.uid is populated.
-        // Without it, fetchRecentMessages uses FETCH (not UID FETCH),
-        // and message.uid stays null — causing delete/move to fall back
-        // to unreliable Message-ID header search.
-        LoggerService.log('IMAP', 'Fetching recent messages (max 50)...');
+        // Envelope-first fetch (no BODY[] = no full message download).
+        // Pulls metadata + RFC822.SIZE so we can decide how to render
+        // and (optionally) cap body download size in fetchFullBody.
+        //
+        // IMPORTANT: Include UID so message.uid is populated for delete/move.
+        LoggerService.log('IMAP', 'Fetching envelopes (max 50, no bodies)...');
         final fetchResult = await client.fetchRecentMessages(
           messageCount: 50,
-          criteria: '(UID FLAGS BODY.PEEK[])',
+          criteria: '(UID FLAGS RFC822.SIZE ENVELOPE BODYSTRUCTURE)',
         );
-        LoggerService.log('IMAP', '✓ Fetched ${fetchResult.messages.length} messages');
+        LoggerService.log('IMAP', '✓ Fetched ${fetchResult.messages.length} envelopes');
 
         for (final message in fetchResult.messages) {
           try {
+            final envelope = message.envelope;
             final email = Email(
-              messageId: message.getHeaderValue('message-id') ??
+              messageId: envelope?.messageId ??
+                  message.getHeaderValue('message-id') ??
                   'CORRUPT-${message.uid}-${DateTime.now().millisecondsSinceEpoch}',
               uid: message.uid,
-              from: message.from?.firstOrNull?.email ?? '(Unknown Sender)',
-              to: message.to?.map((a) => a.email).join(', ') ?? '(Unknown Recipient)',
-              cc: message.cc?.map((a) => a.email).join(', ') ?? '',
-              subject: message.decodeSubject() ?? '(No Subject)',
-              date: message.decodeDate() ?? DateTime.now(),
-              body: _extractEmailBody(message),
+              from: envelope?.from?.firstOrNull?.email ??
+                  message.from?.firstOrNull?.email ??
+                  '(Unknown Sender)',
+              to: envelope?.to?.map((a) => a.email).join(', ') ??
+                  message.to?.map((a) => a.email).join(', ') ??
+                  '(Unknown Recipient)',
+              cc: envelope?.cc?.map((a) => a.email).join(', ') ??
+                  message.cc?.map((a) => a.email).join(', ') ??
+                  '',
+              subject: envelope?.subject ??
+                  message.decodeSubject() ??
+                  '(No Subject)',
+              date: envelope?.date ?? message.decodeDate() ?? DateTime.now(),
+              // body intentionally left null — loaded on demand
+              bodySize: message.size,
               isRead: message.isSeen,
             );
 
-            // Extract headers for threat analysis
+            // Extract headers for threat analysis. Envelope-only fetch
+            // returns no headers, so the threat analyzer just sees from/
+            // subject/etc. Detailed header analysis (SPF/DKIM/auth-results)
+            // happens when the body is loaded.
             for (final header in message.headers ?? []) {
               email.headers[header.name] = header.value;
             }
 
-            // E2EE: Detect PGP/MIME at the MimeMessage level (RFC 3156).
-            // Decrypt body AND extract inner attachments (Proton/Tuta pattern:
-            // outer message is just the PGP wrapper — real MIME is inside).
-            final pgpCiphertext = PgpKeyService.extractPgpCiphertext(message);
-            MimeMessage? decryptedInner;
-            if (pgpCiphertext != null) {
-              try {
-                final packetDump = PgpPacketInspector.summary(pgpCiphertext);
-                LoggerService.log('PGP_INSPECT',
-                    'Message ${email.messageId} packets:\n$packetDump');
-                final decryptedRaw = await PgpKeyService.decrypt(pgpCiphertext);
-                String? body;
-                try {
-                  final crlf = decryptedRaw
-                      .replaceAll('\r\n', '\n')
-                      .replaceAll('\n', '\r\n');
-                  LoggerService.log('PGP',
-                      'Inner MIME raw: ${crlf.length} chars, hasCRLF=${crlf.contains("\r\n")}, '
-                      'first200=${crlf.substring(0, crlf.length > 200 ? 200 : crlf.length).replaceAll("\r", "\\r").replaceAll("\n", "\\n")}');
-                  decryptedInner = MimeMessage.parseFromText(crlf);
-                  final innerCt = decryptedInner.getHeaderContentType();
-                  final boundary = innerCt?.boundary;
-                  if (boundary != null && boundary.isNotEmpty) {
-                    final sections = crlf.split('--$boundary');
-                    for (var i = 1; i < sections.length; i++) {
-                      final section = sections[i];
-                      if (section.startsWith('--')) continue;
-                      var partText = section;
-                      if (partText.startsWith('\r\n')) partText = partText.substring(2);
-                      if (partText.endsWith('\r\n')) partText = partText.substring(0, partText.length - 2);
-                      if (partText.trim().isEmpty) continue;
-                      final partMsg = MimeMessage.parseFromText(partText);
-                      decryptedInner.addPart(partMsg);
-                    }
-                  }
-                  body = decryptedInner.decodeTextPlainPart();
-                  if (body == null || body.isEmpty) {
-                    for (final p in decryptedInner.parts ?? <MimePart>[]) {
-                      final pCt = p.getHeaderContentType()?.mediaType;
-                      if (pCt?.sub == MediaSubtype.textPlain) {
-                        body = p.decodeContentText();
-                        if (body != null && body.isNotEmpty) break;
-                      }
-                    }
-                  }
-                  body ??= decryptedInner.decodeTextHtmlPart();
-                  LoggerService.log('PGP',
-                      'Inner MIME: type=${innerCt?.mediaType}, boundary=$boundary, '
-                      'parts=${decryptedInner.parts?.length ?? 0}, body=${body?.length ?? 0} chars');
-                } catch (parseEx) {
-                  LoggerService.logWarning('PGP',
-                      'Inner MIME parse failed: $parseEx — first 200 chars: ${decryptedRaw.substring(0, decryptedRaw.length > 200 ? 200 : decryptedRaw.length)}');
-                }
-                if (body == null || body.isEmpty) {
-                  final lines = decryptedRaw.split('\n');
-                  var inTextPart = false;
-                  var pastHeader = false;
-                  final contentLines = <String>[];
-                  for (final line in lines) {
-                    final trimmed = line.trim();
-                    if (trimmed.startsWith('Content-Type:') &&
-                        trimmed.contains('text/plain')) {
-                      inTextPart = true;
-                      pastHeader = false;
-                      continue;
-                    }
-                    if (inTextPart && !pastHeader) {
-                      if (trimmed.isEmpty) {
-                        pastHeader = true;
-                        continue;
-                      }
-                      continue;
-                    }
-                    if (inTextPart && pastHeader) {
-                      if (trimmed.startsWith('--')) break;
-                      contentLines.add(line);
-                    }
-                  }
-                  final extracted = contentLines.join('\n').trim();
-                  if (extracted.isNotEmpty) body = extracted;
-                }
-                email.body = body ?? decryptedRaw;
-                email.isEncrypted = true;
-                // RFC 9788: extract protected Subject from decrypted payload
-                final subjectMatch = RegExp(
-                  r'^Subject:\s*(.+)$', multiLine: true,
-                ).firstMatch(decryptedRaw);
-                if (subjectMatch != null && (email.subject == '[...]' || email.subject.isEmpty)) {
-                  var protectedSubject = subjectMatch.group(1)!.trim();
-                  // Decode RFC 2047 if needed
-                  if (protectedSubject.startsWith('=?')) {
-                    try {
-                      final m = RegExp(r'=\?([^?]+)\?([BbQq])\?([^?]+)\?=').firstMatch(protectedSubject);
-                      if (m != null && m.group(2)!.toUpperCase() == 'B') {
-                        protectedSubject = utf8.decode(base64.decode(m.group(3)!));
-                      }
-                    } catch (_) {}
-                  }
-                  email.subject = protectedSubject;
-                }
-                LoggerService.log('PGP',
-                    '✓ Decrypted E2EE email from ${email.from}');
-              } catch (ex) {
-                LoggerService.logWarning('PGP',
-                    'Decryption failed for ${email.messageId}');
-                email.body = '[Encrypted email — decryption failed]';
-                email.isEncrypted = true;
-              }
-            }
-
-            // Analyze threat level
+            // Threat analysis based on envelope fields only.
+            // Full header inspection runs after body load in fetchFullBody.
             final threatAnalysis = ThreatIntelligenceService.analyzeEmail(email);
             email.threatLevel = threatAnalysis.level;
             email.threatScore = threatAnalysis.score;
             email.threatDetails = threatAnalysis.details;
-
-            // Extract attachments: from decrypted inner MIME if encrypted,
-            // otherwise from outer message. PGP/MIME wraps the entire MIME
-            // tree (body + attachments) inside the ciphertext — the outer
-            // message only has application/pgp-encrypted + encrypted.asc.
-            final attachmentSource = decryptedInner ?? message;
-            LoggerService.log('PGP',
-                'Attachment source: ${decryptedInner != null ? "decryptedInner" : "outerMessage"} '
-                '(${attachmentSource.allPartsFlat.length} parts)');
-            for (final part in attachmentSource.allPartsFlat) {
-              final disposition = part.getHeaderContentDisposition();
-              final fileName = part.decodeFileName();
-              final isAttachment = disposition?.disposition == ContentDisposition.attachment;
-              final isInlineWithFile = disposition?.disposition == ContentDisposition.inline && fileName != null && fileName.isNotEmpty;
-              final hasFileNoDisposition = disposition == null && fileName != null && fileName.isNotEmpty && part.mediaType.sub != MediaSubtype.textPlain && part.mediaType.sub != MediaSubtype.textHtml;
-
-              if (isAttachment || isInlineWithFile || hasFileNoDisposition) {
-                final data = part.decodeContentBinary();
-                if (data != null) {
-                  email.attachments.add(EmailAttachment(
-                    fileName: fileName ?? 'unknown',
-                    size: data.length,
-                    contentType: part.mediaType.toString(),
-                    data: data,
-                  ));
-                }
-              }
-            }
-            if (decryptedInner != null && email.attachments.isNotEmpty) {
-              LoggerService.log('PGP',
-                  '✓ Extracted ${email.attachments.length} attachment(s) from encrypted inner MIME');
-            }
 
             emails.add(email);
           } catch (ex, stackTrace) {
@@ -409,7 +293,7 @@ class MailService {
         // Sort emails by date: newest first (descending)
         emails.sort((a, b) => b.date.compareTo(a.date));
 
-        LoggerService.log('IMAP', '✓ Fetched ${emails.length} emails from $folder (sorted newest first)');
+        LoggerService.log('IMAP', '✓ Fetched ${emails.length} envelopes from $folder (sorted newest first)');
         return emails;
       });
     } catch (ex, stackTrace) {
@@ -439,6 +323,238 @@ class MailService {
         );
       }
       LoggerService.logError('IMAP', ex, stackTrace);
+      rethrow;
+    }
+  }
+
+  /// Maximum body size we will fetch in one shot. Messages larger than
+  /// this are still openable: only HEADER + first chunk is downloaded
+  /// and [Email.bodyTruncated] is set so the UI can offer a "download
+  /// full message" action.
+  static const int _maxBodyFetchBytes = 1048576; // 1 MB
+
+  /// Fetch the full body for a single [email] previously returned by
+  /// [fetchEmailsAsync] (envelope-only). Populates `email.body`,
+  /// `email.attachments`, `email.isEncrypted`, and detail header
+  /// fields. Runs PGP/MIME detection + decrypt for E2EE messages.
+  ///
+  /// [folder] is the IMAP folder the email lives in; the caller
+  /// (EmailProvider.loadBody) passes the currently-selected folder
+  /// so we don't have to track that on the Email model.
+  ///
+  /// This is the *only* place where full MIME bodies are downloaded.
+  /// The list/refresh path never calls this.
+  Future<void> fetchFullBody(
+    EmailAccount account,
+    Email email, {
+    String folder = 'INBOX',
+  }) async {
+    _validateAccount(account);
+
+    final uid = email.uid;
+    if (uid == null) {
+      LoggerService.logWarning('IMAP-BODY',
+          'Cannot fetch body for ${email.messageId}: no UID');
+      email.body = '[Cannot load body: message UID missing]';
+      return;
+    }
+
+    try {
+      await ImapPool.instance.withClient(account, (client) async {
+        await client.selectMailboxByPath(folder);
+
+        // Decide fetch strategy by size. Below the cap → full BODY[].
+        // Above the cap → HEADER + first 1 MB to stay responsive on
+        // huge messages (mailing-list digests, 50 MB attachments).
+        final size = email.bodySize ?? 0;
+        final exceedsCap = size > _maxBodyFetchBytes;
+        final fetchSpec = exceedsCap
+            ? '(UID FLAGS BODY.PEEK[HEADER] BODY.PEEK[]<0.$_maxBodyFetchBytes>)'
+            : '(UID FLAGS BODY.PEEK[])';
+
+        LoggerService.log('IMAP-BODY',
+            'Fetching body for UID $uid (${(size / 1024).round()} KB, '
+            '${exceedsCap ? "capped at 1 MB" : "full"})');
+
+        final fetchResult = await client.uidFetchMessages(
+          MessageSequence.fromId(uid, isUid: true),
+          fetchSpec,
+        );
+
+        if (fetchResult.messages.isEmpty) {
+          LoggerService.logWarning(
+              'IMAP-BODY', 'No message returned for UID $uid');
+          email.body = '[Could not load message body]';
+          return;
+        }
+
+        final message = fetchResult.messages.first;
+        email.bodyTruncated = exceedsCap;
+
+        // Pick up any headers we did not have from envelope fetch
+        // (Content-Type, DKIM-Signature, Authentication-Results, etc).
+        for (final header in message.headers ?? []) {
+          email.headers[header.name] = header.value;
+        }
+
+        // ── PGP/MIME detection + decrypt ─────────────────────────────
+        // This is the ONLY place PgpKeyService.extractPgpCiphertext +
+        // PgpPacketInspector.summary + PgpKeyService.decrypt run.
+        // Removed from the envelope-fetch hot path to kill the
+        // [PGP_INSPECT] log spam (×51 per refresh) and 300 MB/refresh
+        // memory churn.
+        final pgpCiphertext = PgpKeyService.extractPgpCiphertext(message);
+        MimeMessage? decryptedInner;
+        if (pgpCiphertext != null) {
+          try {
+            final packetDump = PgpPacketInspector.summary(pgpCiphertext);
+            LoggerService.log('PGP_INSPECT',
+                'Message ${email.messageId} packets:\n$packetDump');
+            final decryptedRaw = await PgpKeyService.decrypt(pgpCiphertext);
+            String? decryptedBody;
+            try {
+              final crlf = decryptedRaw
+                  .replaceAll('\r\n', '\n')
+                  .replaceAll('\n', '\r\n');
+              LoggerService.log('PGP',
+                  'Inner MIME raw: ${crlf.length} chars, hasCRLF=${crlf.contains("\r\n")}, '
+                  'first200=${crlf.substring(0, crlf.length > 200 ? 200 : crlf.length).replaceAll("\r", "\\r").replaceAll("\n", "\\n")}');
+              decryptedInner = MimeMessage.parseFromText(crlf);
+              final innerCt = decryptedInner.getHeaderContentType();
+              final boundary = innerCt?.boundary;
+              if (boundary != null && boundary.isNotEmpty) {
+                final sections = crlf.split('--$boundary');
+                for (var i = 1; i < sections.length; i++) {
+                  final section = sections[i];
+                  if (section.startsWith('--')) continue;
+                  var partText = section;
+                  if (partText.startsWith('\r\n')) partText = partText.substring(2);
+                  if (partText.endsWith('\r\n')) partText = partText.substring(0, partText.length - 2);
+                  if (partText.trim().isEmpty) continue;
+                  final partMsg = MimeMessage.parseFromText(partText);
+                  decryptedInner.addPart(partMsg);
+                }
+              }
+              decryptedBody = decryptedInner.decodeTextPlainPart();
+              if (decryptedBody == null || decryptedBody.isEmpty) {
+                for (final p in decryptedInner.parts ?? <MimePart>[]) {
+                  final pCt = p.getHeaderContentType()?.mediaType;
+                  if (pCt?.sub == MediaSubtype.textPlain) {
+                    decryptedBody = p.decodeContentText();
+                    if (decryptedBody != null && decryptedBody.isNotEmpty) break;
+                  }
+                }
+              }
+              decryptedBody ??= decryptedInner.decodeTextHtmlPart();
+              LoggerService.log('PGP',
+                  'Inner MIME: type=${innerCt?.mediaType}, boundary=$boundary, '
+                  'parts=${decryptedInner.parts?.length ?? 0}, body=${decryptedBody?.length ?? 0} chars');
+            } catch (parseEx) {
+              LoggerService.logWarning('PGP',
+                  'Inner MIME parse failed: $parseEx — first 200 chars: ${decryptedRaw.substring(0, decryptedRaw.length > 200 ? 200 : decryptedRaw.length)}');
+            }
+            if (decryptedBody == null || decryptedBody.isEmpty) {
+              final lines = decryptedRaw.split('\n');
+              var inTextPart = false;
+              var pastHeader = false;
+              final contentLines = <String>[];
+              for (final line in lines) {
+                final trimmed = line.trim();
+                if (trimmed.startsWith('Content-Type:') &&
+                    trimmed.contains('text/plain')) {
+                  inTextPart = true;
+                  pastHeader = false;
+                  continue;
+                }
+                if (inTextPart && !pastHeader) {
+                  if (trimmed.isEmpty) {
+                    pastHeader = true;
+                    continue;
+                  }
+                  continue;
+                }
+                if (inTextPart && pastHeader) {
+                  if (trimmed.startsWith('--')) break;
+                  contentLines.add(line);
+                }
+              }
+              final extracted = contentLines.join('\n').trim();
+              if (extracted.isNotEmpty) decryptedBody = extracted;
+            }
+            email.body = decryptedBody ?? decryptedRaw;
+            email.isEncrypted = true;
+            // RFC 9788: extract protected Subject from decrypted payload
+            final subjectMatch = RegExp(
+              r'^Subject:\s*(.+)$', multiLine: true,
+            ).firstMatch(decryptedRaw);
+            if (subjectMatch != null && (email.subject == '[...]' || email.subject.isEmpty)) {
+              var protectedSubject = subjectMatch.group(1)!.trim();
+              if (protectedSubject.startsWith('=?')) {
+                try {
+                  final m = RegExp(r'=\?([^?]+)\?([BbQq])\?([^?]+)\?=').firstMatch(protectedSubject);
+                  if (m != null && m.group(2)!.toUpperCase() == 'B') {
+                    protectedSubject = utf8.decode(base64.decode(m.group(3)!));
+                  }
+                } catch (_) {}
+              }
+              email.subject = protectedSubject;
+            }
+            LoggerService.log('PGP',
+                '✓ Decrypted E2EE email from ${email.from}');
+          } catch (ex) {
+            LoggerService.logWarning('PGP',
+                'Decryption failed for ${email.messageId}');
+            email.body = '[Encrypted email — decryption failed]';
+            email.isEncrypted = true;
+          }
+        } else {
+          // Plain (non-PGP) message → use enough_mail's part-aware decoder.
+          email.body = _extractEmailBody(message);
+        }
+
+        // Re-run threat analysis now that we have full headers.
+        final threatAnalysis = ThreatIntelligenceService.analyzeEmail(email);
+        email.threatLevel = threatAnalysis.level;
+        email.threatScore = threatAnalysis.score;
+        email.threatDetails = threatAnalysis.details;
+
+        // Extract attachments: from decrypted inner MIME if encrypted,
+        // otherwise from outer message. PGP/MIME wraps the entire MIME
+        // tree (body + attachments) inside the ciphertext.
+        final attachmentSource = decryptedInner ?? message;
+        LoggerService.log('PGP',
+            'Attachment source: ${decryptedInner != null ? "decryptedInner" : "outerMessage"} '
+            '(${attachmentSource.allPartsFlat.length} parts)');
+        for (final part in attachmentSource.allPartsFlat) {
+          final disposition = part.getHeaderContentDisposition();
+          final fileName = part.decodeFileName();
+          final isAttachment = disposition?.disposition == ContentDisposition.attachment;
+          final isInlineWithFile = disposition?.disposition == ContentDisposition.inline && fileName != null && fileName.isNotEmpty;
+          final hasFileNoDisposition = disposition == null && fileName != null && fileName.isNotEmpty && part.mediaType.sub != MediaSubtype.textPlain && part.mediaType.sub != MediaSubtype.textHtml;
+
+          if (isAttachment || isInlineWithFile || hasFileNoDisposition) {
+            final data = part.decodeContentBinary();
+            if (data != null) {
+              email.attachments.add(EmailAttachment(
+                fileName: fileName ?? 'unknown',
+                size: data.length,
+                contentType: part.mediaType.toString(),
+                data: data,
+              ));
+            }
+          }
+        }
+        if (decryptedInner != null && email.attachments.isNotEmpty) {
+          LoggerService.log('PGP',
+              '✓ Extracted ${email.attachments.length} attachment(s) from encrypted inner MIME');
+        }
+      });
+    } catch (ex, stackTrace) {
+      LoggerService.logError('IMAP-BODY', ex, stackTrace);
+      // Preserve a non-null body string so bodyLoaded returns true and
+      // the UI exits the loading spinner. Caller can inspect for the
+      // sentinel if it wants to retry.
+      email.body = '[Failed to load message body: ${ex.toString()}]';
       rethrow;
     }
   }

--- a/lib/views/email_viewer.dart
+++ b/lib/views/email_viewer.dart
@@ -54,18 +54,60 @@ class _EmailViewerState extends State<EmailViewer> {
   /// Whether the user has opted to load remote images for this email.
   bool _allowRemoteContent = false;
 
+  /// Body-load state. Set to true the first time `loadBody` finishes
+  /// (success or sentinel error message). The build method shows a
+  /// ProgressRing while this is false.
+  bool _bodyReady = false;
+  /// Error message from a failed body load. Shown inline instead of the
+  /// body when set.
+  String? _bodyLoadError;
+
   @override
   void initState() {
     super.initState();
-    // Trigger AV scan on all attachments when email is opened.
-    if (widget.email.attachments.isNotEmpty) {
-      AttachmentScanService.scanAll(
-        widget.email,
-        onProgress: () {
-          if (mounted) setState(() {});
-        },
-      );
+    // Envelope-first architecture: the email list only has metadata.
+    // Fetch the body now (or skip if already loaded — e.g. cached).
+    _ensureBodyLoaded();
+  }
+
+  /// Trigger body load on first open. If the body is already populated
+  /// (LRU cache hit, prior open in this session), runs the AV scan
+  /// synchronously. Otherwise shows a spinner until the body arrives.
+  Future<void> _ensureBodyLoaded() async {
+    if (widget.email.bodyLoaded) {
+      _bodyReady = true;
+      _scanAttachments();
+      return;
     }
+    try {
+      // Use listen:false — we don't want to rebuild on every provider
+      // change, only when the body load completes.
+      await context.read<EmailProvider>().loadBody(widget.email);
+      if (!mounted) return;
+      setState(() {
+        _bodyReady = true;
+      });
+      _scanAttachments();
+    } catch (ex) {
+      LoggerService.logError('EMAIL_VIEWER', ex, StackTrace.current);
+      if (!mounted) return;
+      setState(() {
+        _bodyReady = true; // exit spinner; show error inline
+        _bodyLoadError = ex.toString();
+      });
+    }
+  }
+
+  /// Kick off antivirus scanning on any attachments populated by the
+  /// body fetch. Mirrors the pre-envelope behaviour.
+  void _scanAttachments() {
+    if (widget.email.attachments.isEmpty) return;
+    AttachmentScanService.scanAll(
+      widget.email,
+      onProgress: () {
+        if (mounted) setState(() {});
+      },
+    );
   }
 
   @override
@@ -450,15 +492,75 @@ class _EmailViewerState extends State<EmailViewer> {
 
   /// Build email body widget.
   ///
-  /// HTML emails are rendered with [SafeHtmlRenderer] which shows
-  /// formatted content while blocking all remote resources by default.
-  /// Plain-text emails use the existing clickable-text renderer.
+  /// Shows a [ProgressRing] while the body is being fetched on demand
+  /// (envelope-first architecture: the list view only has metadata).
+  /// HTML emails are rendered with [SafeHtmlRenderer]. Plain-text uses
+  /// the clickable-text renderer.
   Widget _buildEmailBody(FluentThemeData theme, Email email) {
-    final isHtml = _isHtmlEmail(email.body, contentType: email.headers['Content-Type'] ?? email.headers['content-type'] ?? '');
+    // Loading state — body fetch in flight.
+    if (!_bodyReady) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 32),
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const ProgressRing(),
+              const SizedBox(height: 12),
+              Text(
+                'Loading message…',
+                style: theme.typography.caption?.copyWith(
+                  color: theme.inactiveColor,
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    // Error state — body fetch failed AND no sentinel populated.
+    if (_bodyLoadError != null && (email.body == null || email.body!.isEmpty)) {
+      return Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: Colors.red.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(color: Colors.red.withValues(alpha: 0.3)),
+        ),
+        child: Text(
+          'Could not load message body:\n$_bodyLoadError',
+          style: theme.typography.body?.copyWith(color: Colors.red),
+        ),
+      );
+    }
+    final body = email.body ?? '';
+    final isHtml = _isHtmlEmail(body, contentType: email.headers['Content-Type'] ?? email.headers['content-type'] ?? '');
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        if (email.bodyTruncated)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              children: [
+                Semantics(
+                  excludeSemantics: true,
+                  child: Icon(FluentIcons.info,
+                      size: 14, color: Colors.orange),
+                ),
+                const SizedBox(width: 6),
+                Flexible(
+                  child: Text(
+                    'Large message — only the first 1 MB was downloaded.',
+                    style: theme.typography.caption?.copyWith(
+                      color: theme.inactiveColor,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
         if (isHtml && !_allowRemoteContent)
           Padding(
             padding: const EdgeInsets.only(bottom: 8),
@@ -498,13 +600,13 @@ class _EmailViewerState extends State<EmailViewer> {
           ),
           child: isHtml
               ? SafeHtmlRenderer(
-                  html: email.body,
+                  html: body,
                   allowRemoteContent: _allowRemoteContent,
                   textStyle: theme.typography.body,
                   onLinkTap: (url, {String? displayText}) => _openUrlInExternalBrowser(url, displayText: displayText),
                 )
               : SelectableText.rich(
-                  _buildClickableText(email.body, theme.typography.body),
+                  _buildClickableText(body, theme.typography.body),
                 ),
         ),
       ],
@@ -623,9 +725,10 @@ class _EmailViewerState extends State<EmailViewer> {
             // pixels and base64 images, and prevents the recipient
             // from receiving raw HTML that could re-render phishing
             // content with full styling.
-            final plainBody = _isHtmlEmail(email.body)
-                ? HtmlToPlainText.convert(email.body)
-                : email.body;
+            final rawBody = email.body ?? '';
+            final plainBody = _isHtmlEmail(rawBody)
+                ? HtmlToPlainText.convert(rawBody)
+                : rawBody;
             final forwardBody = '''
 ${l10nForward.infoForwardedMessage}
 ${l10nForward.labelFrom} ${email.from}
@@ -658,7 +761,7 @@ To: ${email.to}${email.cc.isNotEmpty ? '\nCC: ${email.cc}' : ''}
 Date: ${DateFormat('yyyy-MM-dd HH:mm:ss').format(email.date)}
 Threat: ${email.threatLevel}
 
-${email.body}
+${email.body ?? "(message body not loaded)"}
 
 ${email.attachments.isNotEmpty ? '\nAttachments (${email.attachments.length}): ${email.attachments.map((a) => a.fileName).join(", ")}' : ''}
 ''';
@@ -695,7 +798,7 @@ ${email.attachments.isNotEmpty ? '\nAttachments (${email.attachments.length}): $
             LoggerService.log('EMAIL_VIEWER', 'Copy email button clicked');
             try {
               // Format email for clipboard (strip HTML tags for clean text)
-              final cleanBody = _stripHtmlTags(email.body);
+              final cleanBody = _stripHtmlTags(email.body ?? '');
               final emailContent = '''
 Subject: ${email.subject}
 From: ${email.from}

--- a/lib/views/main_window.dart
+++ b/lib/views/main_window.dart
@@ -1020,12 +1020,20 @@ class _MainWindowState extends State<MainWindow> {
   /// Open draft email in compose window for editing
   Future<void> _openDraftInCompose(BuildContext context, Email email) async {
     LoggerService.log('UI', 'Opening draft in compose: ${email.subject}');
+    // Drafts are envelope-only after PR 2 envelope-first refactor.
+    // Fetch the body before populating the compose window so users
+    // don't open an empty editor and lose the draft's content.
+    if (!email.bodyLoaded) {
+      final provider = context.read<EmailProvider>();
+      await provider.loadBody(email);
+    }
+    if (!context.mounted) return;
     await showDialog(
       context: context,
       builder: (context) => ComposeWindow(
         replyTo: email.to,
         replySubject: email.subject,
-        initialBody: email.body,
+        initialBody: email.body ?? '',
       ),
     );
   }


### PR DESCRIPTION
## Summary

Architectural fix for the 2GB RAM growth. PR #36 wiped outgoing bodies (-35% leak), but the structural issue remained: every 60s auto-refresh allocated 51 full message bodies (up to 8MB SEIPD each, plus PGP_INSPECT parse on every ciphertext). Initial load already cost ~700MB.

- List path now fetches envelopes only: `(UID FLAGS RFC822.SIZE ENVELOPE BODYSTRUCTURE)` — no `BODY[]`, no PGP decode, no `[PGP_INSPECT]` spam
- Body is loaded on demand via new `EmailProvider.loadBody(email)` → `MailService.fetchFullBody(account, email, folder)` with 1 MB cap (`bodyTruncated=true` for larger; UI shows banner)
- `Email.body` is now `String?` (null = not yet loaded); all viewer paths null-safe
- Draft compose awaits `loadBody` before opening dialog so draft content is preserved
- `_wipeBodies` (from PR #36) sets `body=null` + clears attachment shells (not just `.data` buffers)

## Expected impact

| Metric | Before | After |
|---|---|---|
| Initial load (51 emails) | ~700 MB | ~50 MB |
| Per auto-refresh (60s) | ~300 MB allocated | ~3 MB |
| Viewer open | already in `_emails` | one-shot ≤1 MB IMAP fetch |
| `[PGP_INSPECT]` log lines | 51× per refresh | per body open only |

~99% reduction on the critical path.

## Spec note

Codebase uses raw `ImapClient` (via `ImapPool`), not the high-level `MailClient`. Envelope fetch uses the equivalent FETCH criteria string that `FetchPreference.envelope` lowers to internally — same effect, no `MailClient` introduction.

## Test plan
- [ ] flutter analyze lib/ — no NEW issues (pre-existing 6 info warnings remain)
- [ ] Open app → list of 51 emails appears, RSS stays at baseline (~150 MB)
- [ ] Wait 60s → auto-refresh runs, RSS stays flat (verify via [PERF] log lines in app)
- [ ] Click an email → spinner, then body appears
- [ ] Open 5 emails sequentially → RSS grows ~30-50 MB total, plateaus
- [ ] 10 min running → peak < 300 MB
- [ ] Verify [PGP_INSPECT] log line no longer appears per refresh (only per body open)
- [ ] Open a draft → body loads in compose

## Next iteration (PR 3, separate)

Bounded LRU body cache (max 10 entries) so reopening recently-viewed messages does not re-fetch. Predictable RAM ceiling.

## Context

Incident: 2026-05-15/16 — Windows app reaching 2GB RAM. Caught via new `PerfMonitorService` (merged in PR #36) which logs `[PERF] RSS=X MB peak=Y MB delta=ZMB` every 30s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)