### PR TITLE
refactor(provider): LRU body cache (max 10) for re-opened messages

### DIFF
--- a/lib/providers/email_provider.dart
+++ b/lib/providers/email_provider.dart
@@ -3,6 +3,7 @@
 
 import 'package:fluent_ui/fluent_ui.dart';
 import 'dart:async';
+import 'dart:collection' show LinkedHashMap;
 import '../models/models.dart';
 import '../services/services.dart';
 import 'dart:io' show Platform;
@@ -46,14 +47,40 @@ class EmailProvider with ChangeNotifier {
   static const _maxCachePerFolder = 50;
   final Map<String, List<Email>> _sessionCache = {};
 
+  // ── On-demand body LRU cache ──────────────────────────────────────
+  //
+  // Envelope-first fetch (PR #37) means Email.body is null on the list
+  // path. When the user opens a viewer we call loadBody which fetches
+  // from IMAP — and without a body cache, every reopen re-fetches. The
+  // LRU here keeps the last N opened bodies so re-clicks are instant.
+  //
+  // Sizing: hard cap of _maxBodyCacheEntries × max body size. With 1MB
+  // body cap (mail_service.dart) and 10 entries, worst-case RAM
+  // contribution is bounded at ~10MB + attachments. Predictable ceiling,
+  // no possibility of the 300MB/refresh regression we hit pre-PR #36.
+  //
+  // Key: messageId. LinkedHashMap insertion order = LRU order; evict
+  // oldest from the head, touch by re-insert.
+  static const _maxBodyCacheEntries = 10;
+  final LinkedHashMap<String, _CachedBody> _bodyCache =
+      LinkedHashMap<String, _CachedBody>();
+
   /// Wipe all cached emails from RAM. Called on lock, background, close.
   void wipeSessionCache() {
     for (final emails in _sessionCache.values) {
       _wipeBodies(emails);
     }
     _sessionCache.clear();
+    // Also drop the LRU body cache — bodies are decrypted plaintext, must
+    // not survive a lock or background transition.
+    for (final cached in _bodyCache.values) {
+      for (final a in cached.attachments) {
+        a.data = null;
+      }
+    }
+    _bodyCache.clear();
     _emails = [];
-    LoggerService.log('CACHE', 'Session cache wiped from RAM');
+    LoggerService.log('CACHE', 'Session cache + body LRU wiped from RAM');
   }
 
   /// Release heavy body strings + attachment buffers before dropping the
@@ -1170,7 +1197,31 @@ class EmailProvider with ChangeNotifier {
   ///
   /// Idempotent: if `email.bodyLoaded` is already true, this is a no-op.
   Future<void> loadBody(Email email) async {
-    if (email.bodyLoaded) return;
+    // Already loaded on this Email instance — just touch the LRU.
+    if (email.bodyLoaded) {
+      _touchBodyCache(email.messageId);
+      return;
+    }
+
+    // Cache hit on a different Email shell (same messageId, e.g. after
+    // an envelope-only refresh replaced the list). Hydrate from cache,
+    // skip the IMAP fetch entirely.
+    final cached = _bodyCache[email.messageId];
+    if (cached != null) {
+      email.body = cached.body;
+      email.bodyTruncated = cached.bodyTruncated;
+      email.isEncrypted = cached.isEncrypted;
+      email.attachments
+        ..clear()
+        ..addAll(cached.attachments);
+      _touchBodyCache(email.messageId);
+      LoggerService.log('CACHE',
+          '✓ Body cache HIT for ${email.messageId} (size=${_bodyCache.length})');
+      if (!_disposed) notifyListeners();
+      return;
+    }
+
+    // Cache miss — fetch from IMAP.
     final account = _currentAccount;
     if (account == null) {
       LoggerService.logWarning(
@@ -1183,11 +1234,42 @@ class EmailProvider with ChangeNotifier {
           '✓ Loaded body for ${email.messageId} (${email.body?.length ?? 0} chars, '
           '${email.attachments.length} attachments, '
           'encrypted=${email.isEncrypted}, truncated=${email.bodyTruncated})');
+      // Insert into LRU on success only (don't pollute cache with errors).
+      if (email.bodyLoaded) {
+        _putBodyCache(email);
+      }
     } catch (ex, stackTrace) {
       // fetchFullBody already populated email.body with an error sentinel.
       LoggerService.logError('PROVIDER', ex, stackTrace);
     } finally {
       if (!_disposed) notifyListeners();
+    }
+  }
+
+  /// Move existing entry to end (most-recently-used) without re-storing.
+  void _touchBodyCache(String messageId) {
+    final entry = _bodyCache.remove(messageId);
+    if (entry != null) _bodyCache[messageId] = entry;
+  }
+
+  /// Store body+attachments in LRU; evict oldest if over capacity.
+  void _putBodyCache(Email email) {
+    _bodyCache[email.messageId] = _CachedBody(
+      body: email.body!,
+      bodyTruncated: email.bodyTruncated,
+      isEncrypted: email.isEncrypted,
+      attachments: List<EmailAttachment>.from(email.attachments),
+    );
+    while (_bodyCache.length > _maxBodyCacheEntries) {
+      final evictId = _bodyCache.keys.first;
+      final evicted = _bodyCache.remove(evictId);
+      if (evicted != null) {
+        for (final a in evicted.attachments) {
+          a.data = null;
+        }
+      }
+      LoggerService.log('CACHE',
+          'Evicted body for $evictId (cache full at $_maxBodyCacheEntries)');
     }
   }
 
@@ -1270,4 +1352,23 @@ class EmailProvider with ChangeNotifier {
       LoggerService.log('TRASH_CLEANUP', '✓ No old emails to clean in Trash folders');
     }
   }
+}
+
+/// Snapshot of a loaded message body for the LRU cache. We don't keep a
+/// reference to the original Email because the envelope-only refresh path
+/// replaces the Email shell — the body would point to a dead instance.
+/// Storing the raw fields lets us re-hydrate any future Email shell with
+/// the same messageId.
+class _CachedBody {
+  final String body;
+  final bool bodyTruncated;
+  final bool isEncrypted;
+  final List<EmailAttachment> attachments;
+
+  _CachedBody({
+    required this.body,
+    required this.bodyTruncated,
+    required this.isEncrypted,
+    required this.attachments,
+  });
 }


### PR DESCRIPTION
## Summary

Stacked on top of #37. With envelope-first fetch, every viewer open triggered a fresh IMAP fetch even for messages just closed. This adds a bounded LRU so repeats are instant from RAM, with a predictable ceiling.

- `LinkedHashMap<String, _CachedBody>` keyed by messageId; insertion order = LRU order
- Hard cap **10 entries**. Worst-case RAM = 10 × 1MB body cap + attachment buffers (~10-15MB total)
- Insert only on successful load (errors don't pollute)
- `loadBody` flow:
  1. `email.bodyLoaded` → touch cache, return (idempotent)
  2. Cache hit on different Email shell (after envelope refresh replaced the instance) → hydrate from `_CachedBody`, skip IMAP
  3. Cache miss → `fetchFullBody`, store, evict oldest if over cap
- `wipeSessionCache()` also clears `_bodyCache` (decrypted plaintext must not survive lock/background)

## Why `_CachedBody` snapshot instead of Email reference

Envelope-only refresh path replaces Email shells with fresh instances. A stored `Email` reference would point to a dead instance after the next list refresh. Storing the raw fields lets us re-hydrate any future Email shell with the same messageId.

## Test plan
- [ ] Open 11 different emails sequentially → 11th triggers eviction of oldest (log: `Evicted body for ...`)
- [ ] Reopen the evicted one → IMAP fetch happens (spinner appears)
- [ ] Reopen one within last 10 → instant (log: `Body cache HIT`), no spinner
- [ ] Auto-refresh runs (envelope replaces shells) → reopen a cached message → still hits cache
- [ ] Lock or background app → reopen → cache wiped, IMAP fetch on next open

## Stacking note

This PR targets `refactor/envelope-first-fetch` (PR #37) as base, since the LRU logic depends on `loadBody` + `fetchFullBody` from that branch. **Merge order: #37 first, then this one** (GitHub will rebase to main automatically on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)