### PR TITLE
fix(update): rotate version.json signing key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,11 @@ TODO.txt
 *.gpg
 *.asc.tmp
 
+version_signing_priv.pem
+version_signing_pub.pem
+
+# Server-side ops scripts staged locally before scp/deploy.
+# Kept untracked so they don't leak infrastructure details into the app repo.
+sign-version-json.sh
+sign-version-json.service
+sign-version-json.path

--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -64,17 +64,31 @@ class UpdateService {
   /// format `0x04 || X || Y`) used to verify the detached signature on
   /// `version.json`.
   ///
-  /// SECURITY: The matching private key is held offline at
-  /// `/root/.icd360s/release_signing/version_signing_priv.pem` on the
-  /// release-signing host (Claude Code dev server, NOT mail.icd360s.de).
-  /// A compromise of `mail.icd360s.de` cannot forge update metadata
-  /// because the attacker would need this offline private key.
+  /// Rotated 2026-05-16: the previous keypair (whose pubkey started with
+  /// `BOaKDVWITCwis2+9tVGN…`) signed up to v2.136.1; its private key was
+  /// lost so the active version.json froze for 5 days and no client could
+  /// auto-update past v2.136.1. New keypair generated offline and
+  /// installed at `/root/.icd360s/release_signing/version_signing_priv.pem`
+  /// on mail.icd360s.de; a systemd path-watcher (`sign-version-json.path`)
+  /// auto-signs every `version.json.draft` that CI rsyncs into
+  /// `/var/www/html/downloads/mail/`.
   ///
-  /// To rotate: generate a new keypair offline, ship a release that
-  /// trusts BOTH the old and the new key, wait for adoption, ship a
-  /// follow-up release that trusts only the new key.
+  /// Trust-model note: by living on mail.icd360s.de the key is no longer
+  /// strictly "offline" — a root compromise of that host can forge update
+  /// metadata. Acceptable because the same host already terminates IMAP/
+  /// SMTP, holds the user CA, and is the canonical source of binaries, so
+  /// a root compromise there is game-over regardless. Follow-up: migrate
+  /// signing into CI using `VERSION_SIGNING_PRIVATE_KEY` GitHub Secret so
+  /// the key never lives on the mail host.
+  ///
+  /// To rotate again: generate a new keypair, ship a release whose pinned
+  /// key is the NEW one, then on the server replace
+  /// `/root/.icd360s/release_signing/version_signing_priv.pem` and trigger
+  /// `systemctl start sign-version-json.service` to re-sign the current
+  /// draft. Clients on older releases stay pinned to the previous key and
+  /// must be updated out-of-band (manual download).
   static const String _versionJsonPublicKey =
-      'BOaKDVWITCwis2+9tVGNkeNPBsV0dO/ja3HheaaqVW6GZbb6Y6csarYVoMpCFH7FTprFSwfZP1JO72fRu2x6te0=';
+      'BI+YZXuq+/fhMPMVYU3J4mKrzghAqEF0cInvGUHJ1PRezIU8PwA/02p/w/Q6gzrq/+SwcxEJBHOmzLioyscxIqA=';
 
   static const String _expectedApkCertSha256 =
       'ff9c4a92347693745a06a20cc15310e897145dad6b719cbe724eda093a6195b5';


### PR DESCRIPTION
## Why

The previous ECDSA P-256 keypair signed `version.json` up to v2.136.1 on 2026-05-11. The private key was then lost — searches across mail.icd360s.de, this dev machine, and GitHub Secrets all came up empty. As a result `/var/www/html/updates/version.json` froze at 2.136.1 for 5 days. All clients (mobile + desktop) silently stayed on v2.136.1 because the update URL never advertised anything newer, even though v2.136.2…v2.136.6 had shipped to GitHub Releases.

## What

- New ECDSA P-256 keypair generated offline (`openssl ecparam -name prime256v1 -genkey`). Private key uploaded to mail.icd360s.de at `/root/.icd360s/release_signing/version_signing_priv.pem` (mode 400, root-only).
- `_versionJsonPublicKey` in `lib/services/update_service.dart` updated to the new pubkey. Source comment rewritten to document the rotation, the new auto-signer location, and the trust-model trade-off.
- On the server (deployed separately, not in this PR — server-side ops live outside the app repo and are kept untracked via `.gitignore`):
  - `/usr/local/sbin/sign-version-json.sh` — validates draft JSON, signs with `openssl dgst -sha256 -sign`, atomic-renames into `/var/www/html/updates/`, restorecon SELinux.
  - `sign-version-json.path` — systemd path-unit watching `/var/www/html/downloads/mail/version.json.draft` (the file CI rsyncs).
  - `sign-version-json.service` — oneshot, hardened (`ProtectSystem=strict`, `ReadWritePaths` minimal).
- v2.136.4 already signed manually on the server immediately after rollout so clients aren't stuck waiting on this PR to merge.

## Impact on existing users

| Client version | Behavior after this merge |
| --- | --- |
| v2.137.0+ (post-merge) | Auto-update works normally |
| v2.136.4 (manually installed today) | Auto-update works (server already signed) |
| v2.136.1 (e.g. user's mobile) | **Cannot auto-update.** Old pubkey is pinned in-app and rejects the new signature. Must download manually from https://mail.icd360s.de/downloads/mail/ |

## Test plan

- [x] `openssl dgst -sha256 -verify` against new pubkey on signed `/var/www/html/updates/version.json` → "Verified OK"
- [x] `curl https://mail.icd360s.de/updates/version.json` returns `{"version": "2.136.4", ...}`
- [x] `flutter analyze lib/services/update_service.dart` — no new lints
- [ ] After merge: confirm v2.137.0 builds, CI rsyncs new draft, systemd path-watcher fires within 1s, live URL flips to 2.137.0
- [ ] Install v2.137.0 manually on test device, then publish v2.137.1, confirm the test device auto-updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)