### PR TITLE
fix(ci): sign version.json in CI with GitHub Secret

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -1037,17 +1037,24 @@ jobs:
           done
 
       # ============================================================
-      # H2: Generate UNSIGNED version.json.draft
+      # Generate + sign version.json in CI
       #
-      # The H2 signing key is held offline on the dev host
-      # (alma-8gb-fsn1-1) and intentionally NEVER reaches GitHub
-      # Actions. This step writes a draft manifest with the freshly-
-      # computed SHA-256 of every newly-built binary; a cron job on
-      # the dev host polls /downloads/mail/version.json.draft, signs
-      # it with the offline ECDSA P-256 key, and atomically publishes
-      # version.json + version.json.sig to /updates/.
+      # The ECDSA P-256 signing key lives in the VERSION_SIGNING_PRIVATE_KEY
+      # GitHub Secret (encrypted at rest in Actions). It never touches the
+      # mail.icd360s.de filesystem — so even a root compromise of that host
+      # cannot forge an update manifest accepted by clients (which pin the
+      # matching pubkey in lib/services/update_service.dart).
+      #
+      # The signed pair (version.json + version.json.sig) is rsynced into
+      # /var/www/html/downloads/mail/ by the next step. A systemd path-
+      # watcher on the server (promote-version-json.path) verifies the
+      # signature against the pinned pubkey and atomically copies both into
+      # /var/www/html/updates/ where clients fetch them. The server never
+      # holds the private key.
       # ============================================================
-      - name: Generate version.json.draft (unsigned manifest for H2 signer)
+      - name: Generate + sign version.json
+        env:
+          SIGNING_KEY: ${{ secrets.VERSION_SIGNING_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           DEPLOY_DIR="deploy/downloads/mail"
@@ -1070,7 +1077,7 @@ jobs:
 
           CHANGELOG="Automated build for ${GITHUB_REF_NAME}. See https://github.com/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME} for full release notes."
 
-          cat > "${DEPLOY_DIR}/version.json.draft" <<EOF
+          cat > "${DEPLOY_DIR}/version.json" <<EOF
           {
             "version": "${VERSION}",
             "download_url": "https://mail.icd360s.de/downloads/mail/windows/icd360s-mail-setup.exe",
@@ -1087,13 +1094,24 @@ jobs:
           }
           EOF
 
-          # Validate JSON before letting it leave the runner
-          python3 -c "import json,sys; json.load(open(sys.argv[1]))" "${DEPLOY_DIR}/version.json.draft"
+          # Validate JSON before signing
+          python3 -c "import json,sys; json.load(open(sys.argv[1]))" "${DEPLOY_DIR}/version.json"
 
-          echo "## H2 draft manifest" >> "$GITHUB_STEP_SUMMARY"
+          # Sign with the secret-managed ECDSA P-256 key. The key file is
+          # written to the runner's tmpfs (/tmp) and deleted immediately
+          # after signing — never persisted to the artifact or the deploy.
+          KEY_PATH=$(mktemp --tmpdir=/tmp sign.XXXXXX.pem)
+          trap 'shred -u "$KEY_PATH" 2>/dev/null || rm -f "$KEY_PATH"' EXIT
+          printf '%s\n' "$SIGNING_KEY" > "$KEY_PATH"
+          openssl dgst -sha256 -sign "$KEY_PATH" \
+            -out "${DEPLOY_DIR}/version.json.sig" \
+            "${DEPLOY_DIR}/version.json"
+
+          echo "## Signed version.json manifest" >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
-          cat "${DEPLOY_DIR}/version.json.draft" >> "$GITHUB_STEP_SUMMARY"
+          cat "${DEPLOY_DIR}/version.json" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "Signature: \`$(wc -c < "${DEPLOY_DIR}/version.json.sig") bytes\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Generate changelog.json from CHANGELOG.md
         run: |
@@ -1152,7 +1170,7 @@ jobs:
               "https://mail.icd360s.de/updates/version.json?_cb=$(date +%s%N)" 2>&1) || {
               echo "::warning::Attempt $attempt: version.json not yet available"
               [ "$attempt" -lt 3 ] && sleep 15 && continue
-              echo "version.json not reachable after 3 attempts (H2 signer may still be processing)" >> "$GITHUB_STEP_SUMMARY"
+              echo "version.json not reachable after 3 attempts (server promote-version-json watcher may still be processing)" >> "$GITHUB_STEP_SUMMARY"
               exit 0
             }
 
@@ -1170,7 +1188,7 @@ jobs:
             [ "$attempt" -lt 3 ] && sleep 15
           done
 
-          echo "::warning::Version not yet updated after 3 attempts (deployed=$deployed, expected=$expected). H2 signer may still be processing."
+          echo "::warning::Version not yet updated after 3 attempts (deployed=$deployed, expected=$expected). server promote-version-json watcher may still be processing."
           echo "Version not yet updated: deployed=$deployed, expected=$expected (H2 signer pending)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Cleanup SSH

--- a/.gitignore
+++ b/.gitignore
@@ -125,5 +125,8 @@ version_signing_pub.pem
 sign-version-json.sh
 sign-version-json.service
 sign-version-json.path
+promote-version-json.sh
+promote-version-json.service
+promote-version-json.path
 sync-numeric-aliases.sh
 create_email_account.sh


### PR DESCRIPTION
## Why

Follow-up to #40: that PR rotated the version-signing key and put the private key + auto-signer on mail.icd360s.de. That worked, but the new key sat alongside everything else the mail host already controls (CA, binaries, IMAP/SMTP data) — a root compromise there could forge updates.

This PR moves the signing into CI so the mail host never holds the private key.

## What

**CI side (this PR):**
- New GitHub Secret `VERSION_SIGNING_PRIVATE_KEY` (uploaded out of band).
- `build-all-platforms.yml` "Generate version.json.draft" step rewritten to "Generate + sign version.json": writes the JSON, signs with `openssl dgst -sha256 -sign` using the secret loaded into a `/tmp` mktemp file, `shred -u`s the key on exit, ships both `version.json` and `version.json.sig` as part of the rsync payload (instead of the unsigned `.draft`).

**Server side (deployed out of band, kept untracked):**
- `/etc/icd360s/version_signing_pub.pem` — pinned public key (extracted from the secret keypair).
- `/usr/local/sbin/promote-version-json.sh` — verifies the CI signature against the pinned pubkey via `openssl dgst -verify`, atomic-renames the pair into `/var/www/html/updates/`, restorecon.
- `promote-version-json.path` (PathModified on `/var/www/html/downloads/mail/`) + `promote-version-json.service` (oneshot, hardened) — replace the old `sign-version-json.*` units which are now disabled.

## Threat model delta

| Before | After |
| --- | --- |
| Root on mail.icd360s.de → can sign any version.json with the local key → clients accept malicious update | Root on mail.icd360s.de → can replace `/updates/version.json` with anything, but clients reject signature (no private key on host) |
| Compromise blast radius: update channel + all other mail-host assets | Compromise blast radius: only the other mail-host assets — update channel stays safe |

## Test plan

- [x] Local syntax check (`bash -n`) on promote-version-json.sh
- [x] systemd units load cleanly (`systemctl daemon-reload && systemctl status promote-version-json.path` → active waiting)
- [x] Pubkey installed at `/etc/icd360s/version_signing_pub.pem` (444 root:root)
- [x] Old `sign-version-json.path` disabled + masked path-unit symlink removed
- [ ] After merge: tag bump triggers build → CI signing step succeeds → rsync uploads signed pair → promote watcher fires → live URL serves new version
- [ ] After verification: remove `/root/.icd360s/release_signing/version_signing_priv.pem` from mail.icd360s.de

## Roll-forward only

This change is intentionally not backwards-compatible with the old workflow: if reverted, the server has no `sign-version-json.path` enabled anymore, so deploys would stop being promoted. To roll back: revert this PR AND re-enable the old units on the server (`systemctl enable --now sign-version-json.path`). The private key is still on the server during the transition window — it stays until we confirm one full release cycle works through CI signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)