### PR TITLE
fix(fetch): skip headers with null name/value (365 FETCH-EMAIL errors)

### DIFF
--- a/lib/services/mail_service.dart
+++ b/lib/services/mail_service.dart
@@ -272,8 +272,14 @@ class MailService {
             // returns no headers, so the threat analyzer just sees from/
             // subject/etc. Detailed header analysis (SPF/DKIM/auth-results)
             // happens when the body is loaded.
+            // Skip headers with null name/value — enough_mail surfaces them
+            // for malformed messages, and our Map<String,String> rejects null.
             for (final header in message.headers ?? []) {
-              email.headers[header.name] = header.value;
+              final name = header.name;
+              final value = header.value;
+              if (name != null && value != null) {
+                email.headers[name] = value;
+              }
             }
 
             // Threat analysis based on envelope fields only.
@@ -393,8 +399,14 @@ class MailService {
 
         // Pick up any headers we did not have from envelope fetch
         // (Content-Type, DKIM-Signature, Authentication-Results, etc).
+        // Same null guard as envelope-fetch: malformed headers may surface
+        // null name/value via enough_mail; our Map<String,String> rejects them.
         for (final header in message.headers ?? []) {
-          email.headers[header.name] = header.value;
+          final name = header.name;
+          final value = header.value;
+          if (name != null && value != null) {
+            email.headers[name] = value;
+          }
         }
 
         // ── PGP/MIME detection + decrypt ─────────────────────────────


### PR DESCRIPTION
## Why

User on v2.136.9 (just installed) sees zero CR/LF errors (PR #42 worked ✓) but the log shows **365 `[FETCH-EMAIL] type 'Null' is not a subtype of type 'String'`** errors in a single fetch.

Root cause: `MailService.fetchEmailsAsync` copies `message.headers` into `Email.headers` which is `Map<String, String>` (non-nullable values). `enough_mail` surfaces `Header` objects with **nullable** `.name` and `.value` for malformed messages (auto-notification senders strip headers, some servers send garbage). Assigning null into the non-nullable Map throws — and the entire message is then `continue`-skipped from the result list.

Stack trace from production log:
```
[06:02:14] [ERROR] [FETCH-EMAIL] type 'Null' is not a subtype of type 'String'
  StackTrace: MailService.fetchEmailsAsync.<anonymous closure>
              (lib/services/mail_service.dart:276)
```

## What

Defensive null guard in both header-copy sites:
- Line 276 (envelope fetch hot path)
- Line 403 (body-load path `fetchFullBody`)

Pattern:
```dart
for (final header in message.headers ?? []) {
  final name = header.name;
  final value = header.value;
  if (name != null && value != null) {
    email.headers[name] = value;
  }
}
```

## Test plan
- [x] `flutter analyze lib/services/mail_service.dart` — 3 pre-existing unrelated info lints, zero errors
- [ ] After build: refresh INBOX on an account with auto-notification senders, confirm zero `[FETCH-EMAIL]` errors in log
- [ ] Confirm those messages now appear in the list (previously continue-skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)