### PR TITLE
feat(compose): per-account email signature with ICD360S e.V. default

### DIFF
--- a/lib/models/email_account.dart
+++ b/lib/models/email_account.dart
@@ -26,6 +26,12 @@ class EmailAccount {
   bool isActive;
   int inboxCount;
 
+  /// Signature auto-appended to new outgoing emails (after RFC 3676 "-- " marker).
+  /// Stored per-account so switching accounts in compose swaps the signature.
+  /// Empty by default; populated either via account settings UI or
+  /// [defaultSignatureFor] for known accounts.
+  String signature;
+
   // Folders fetched from server (not serialized, loaded dynamically)
   List<String> folders;
 
@@ -50,6 +56,7 @@ class EmailAccount {
     this.lastFolder = 'INBOX',
     this.isActive = true,
     this.inboxCount = 0,
+    this.signature = '',
     List<String>? folders,
     Map<String, int>? folderCounts,
     this.connectionStatus = AccountConnectionStatus.unknown,
@@ -68,6 +75,7 @@ class EmailAccount {
       'lastFolder': lastFolder,
       'isActive': isActive,
       'inboxCount': inboxCount,
+      'signature': signature,
       // Note: folders, folderCounts, and password are not serialized
     };
   }
@@ -83,7 +91,52 @@ class EmailAccount {
       lastFolder: json['lastFolder'] as String? ?? 'INBOX',
       isActive: json['isActive'] as bool? ?? true,
       inboxCount: json['inboxCount'] as int? ?? 0,
+      signature: (json['signature'] as String?) ??
+          defaultSignatureFor(json['username'] as String? ?? ''),
     );
+  }
+
+  /// Built-in default signature for known ICD360S e.V. mailboxes. Used as
+  /// fallback when no stored signature exists yet (one-time migration for
+  /// installs upgrading to client versions that introduce signature support).
+  /// Returns '' for unknown accounts.
+  static String defaultSignatureFor(String username) {
+    final addr = username.toLowerCase();
+    if (addr == 'icd@icd360s.de') {
+      // Mandatory disclosures per § 5 TMG / § 26 BGB for an eingetragener
+      // Verein: full association name, business address, Vertretungsberechtigter
+      // (Vorstand) and Vereinsregister (court + VR-Nr). Tagline is the
+      // association's official acronym expansion (Integration · Chancen ·
+      // Diversity · 360° Support) as shown on icd360s.de header.
+      return '''Freundliche Grüße
+
+Ionuț Claudiu Duinea
+1. Vorsitzender
+____________________________________________
+
+
+ICD360S e.V.
+Eingetragener gemeinnütziger Verein
+
+c/o Ionuț-Claudiu Duinea
+Elsa-Brändström-Str. 13
+89231 Neu-Ulm
+
+E-Mail:    icd@icd360s.de
+Internet:  www.icd360s.de
+
+Amtsgericht Memmingen · VR 201335
+Gemeinnützig anerkannt
+
+Integration · Chancen · Diversity
+360° Support
+____________________________________________
+Diese E-Mail ist ausschließlich für den Adressaten/die Adressatin bestimmt
+und kann vertrauliche oder gesetzlich geschützte Informationen enthalten.
+Wenn Sie nicht der/die bestimmungsgemäße Adressat/-in sind, unterrichten
+Sie bitte den Absender/die Absenderin und vernichten Sie diese E-Mail.''';
+    }
+    return '';
   }
 
   /// Create a copy of this account with optional field modifications
@@ -96,6 +149,7 @@ class EmailAccount {
     String? lastFolder,
     bool? isActive,
     int? inboxCount,
+    String? signature,
     List<String>? folders,
     Map<String, int>? folderCounts,
     AccountConnectionStatus? connectionStatus,
@@ -110,6 +164,7 @@ class EmailAccount {
       lastFolder: lastFolder ?? this.lastFolder,
       isActive: isActive ?? this.isActive,
       inboxCount: inboxCount ?? this.inboxCount,
+      signature: signature ?? this.signature,
       folders: folders ?? List.from(this.folders),
       folderCounts: folderCounts ?? Map.from(this.folderCounts),
       connectionStatus: connectionStatus ?? this.connectionStatus,

--- a/lib/views/compose_window.dart
+++ b/lib/views/compose_window.dart
@@ -113,12 +113,24 @@ class _ComposeWindowState extends State<ComposeWindow> {
     _subjectController = TextEditingController(
       text: widget.replySubject ?? '',
     );
-    _bodyController = TextEditingController(text: widget.initialBody ?? '');
 
-    // Set default account
+    // Set default account FIRST — needed below to seed signature.
     final emailProvider = context.read<EmailProvider>();
     _selectedAccount = emailProvider.currentAccount;
     LoggerService.log('COMPOSE', 'Default account: ${_selectedAccount != null ? piiEmail(_selectedAccount!.username) : "none"}');
+
+    // Body seed: replies/forwards already carry quoted text in initialBody —
+    // leave those untouched. New empty composes get the account signature
+    // pre-pended, separated by the RFC 3676 "-- " sigdash marker so MUAs
+    // can fold/strip it. Cursor lands at row 0 so the user types above.
+    final sig = _selectedAccount?.signature ?? '';
+    final hasInitialBody = (widget.initialBody ?? '').isNotEmpty;
+    if (!hasInitialBody && sig.isNotEmpty) {
+      _bodyController = TextEditingController(text: '\n\n-- \n$sig');
+      _bodyController.selection = const TextSelection.collapsed(offset: 0);
+    } else {
+      _bodyController = TextEditingController(text: widget.initialBody ?? '');
+    }
 
     // Start auto-save timer (every 5 seconds)
     _autoSaveTimer = Timer.periodic(const Duration(seconds: 5), (_) => _autoSaveDraft());


### PR DESCRIPTION
Adds an optional `signature` field to `EmailAccount` that is auto-appended to NEW compose windows after the RFC 3676 "-- " sigdash marker. Replies and forwards skip the auto-append since they already carry quoted text (would double the sender's signature on reply chains).

The cursor is placed at line 0 so the user types the message body above the signature, mirroring Thunderbird/Gmail behaviour.

`defaultSignatureFor(username)` provides a built-in template for the `icd@icd360s.de` mailbox containing the full set of legal disclosures required of an eingetragener Verein under § 5 TMG and § 26 BGB:
  • association name + legal status (gemeinnütziger Verein)
  • postal address (c/o address per Vorstand)
  • Vorstand named (1. Vorsitzender) + contact
  • Amtsgericht Memmingen · VR 201335
  • official tagline (Integration · Chancen · Diversity · 360° Support)
  • confidentiality disclaimer

`fromJson` falls back to this template when no stored signature exists, acting as a one-time migration for installs upgrading to this version. Future settings UI can let the user edit/override the value (persisted via the new `signature` key in `toJson`).

## Summary

<!-- What does this PR do? -->

## Changes

- 

## Checklist

- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `flutter analyze` passes with no issues
- [ ] Tested on at least one platform
- [ ] No sensitive data (keys, passwords, server details) in the code
- [ ] Updated CHANGELOG.md if user-facing change
