### PR TITLE
fix(ci): tag-isolated concurrency + fail loudly when RELEASE_PAT is unset

### DIFF
--- a/.github/workflows/auto-version.yml
+++ b/.github/workflows/auto-version.yml
@@ -22,6 +22,24 @@ jobs:
     if: "!startsWith(github.event.head_commit.message, 'chore(version):')"
 
     steps:
+      - name: Verify RELEASE_PAT is configured
+        # Without RELEASE_PAT the checkout silently falls back to the
+        # default GITHUB_TOKEN, and any tag we push later WILL NOT trigger
+        # build-all-platforms.yml (per GitHub's anti-recursion design for
+        # GITHUB_TOKEN). That silently breaks the release pipeline — see
+        # the v2.136.11 / v2.137.0 missed builds. Fail loudly instead.
+        env:
+          PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ -z "$PAT" ]; then
+            echo "::error::RELEASE_PAT secret is not configured. Tag push from this workflow"
+            echo "::error::will not trigger build-all-platforms.yml, so no release binaries"
+            echo "::error::will be built. Configure RELEASE_PAT in repo Settings → Secrets →"
+            echo "::error::Actions (PAT must have 'repo' + 'workflow' scopes)."
+            exit 1
+          fi
+          echo "✓ RELEASE_PAT is configured"
+
       - name: Checkout (full history required for cocogitto)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -17,9 +17,14 @@ on:
       - '.github/workflows/build-all-platforms.yml'
   workflow_dispatch:
 
+# Concurrency: PR / branch pushes share a group and cancel the previous
+# run on new commits (saves CI minutes). Tag pushes (v*) get an isolated
+# group per tag AND opt out of cancellation so a release build is never
+# killed by a concurrent dependabot PR — that's how v2.136.11 and v2.137.0
+# were lost previously (PR sync triggered cancel-in-progress on the tag run).
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
 # SECURITY: Default least-privilege permissions for all jobs.
 # Individual jobs override as needed (e.g., 'release' needs contents: write).


### PR DESCRIPTION
## Summary

Two compounding bugs silently broke v2.136.11 and v2.137.0 release pipelines:

1. **Concurrency bug** — `build-all-platforms.yml` used a single per-workflow group with `cancel-in-progress: true`, so a PR sync running during a tag-push build cancelled the release build mid-compile. Fix: include `github.ref` in the group; disable cancellation for `refs/tags/v*`.
2. **Silent PAT fallback** — `auto-version.yml` references `secrets.RELEASE_PAT` but checkout falls back to GITHUB_TOKEN silently if missing. Tag pushes under GITHUB_TOKEN don't trigger downstream workflows (GitHub anti-recursion). Fix: explicit pre-flight that fails with `::error::` instructions when `RELEASE_PAT` is empty.

## Operator action required after merge
- Add `RELEASE_PAT` repo secret (token with `repo` + `workflow` scopes) at Settings → Secrets → Actions
- Optionally manually trigger Build All Platforms for v2.137.0 (was lost) via workflow_dispatch

## Test plan
- [ ] After merge + RELEASE_PAT set, any feat:/fix: commit on main triggers auto-version → tag push → BAP runs to completion
- [ ] dependabot PR opened during release build does NOT cancel it
- [ ] If RELEASE_PAT is unset, auto-version fails loudly instead of silently breaking the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)