### PR TITLE
ci: inject SENTRY_DSN + release tag in 5 platform builds

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -183,7 +183,10 @@ jobs:
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libsecret-1-dev rpm ruby-dev
+          # libcurl4-openssl-dev: sentry-native (sentry_flutter desktop backend)
+          # links libcurl at compile time. Without it, CMake fails with
+          # "Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)".
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libstdc++-12-dev libsecret-1-dev libcurl4-openssl-dev rpm ruby-dev
           sudo gem install fpm
 
       - name: Cache native build hooks (sodium)
@@ -198,7 +201,10 @@ jobs:
         run: flutter pub get --enforce-lockfile
 
       - name: Compile Linux release binary
-        run: flutter build linux --release
+        run: |
+          flutter build linux --release \
+            --dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
+            --dart-define=SENTRY_RELEASE=mail-client-app@${{ github.ref_name }}+${{ github.run_number }}
 
       # SECURITY (M9): Declare libsecret-1-0 as a runtime dependency.
       # flutter_secure_storage_linux requires libsecret to use the system
@@ -507,7 +513,9 @@ jobs:
           BUILD_ARGS: ${{ matrix.build_args }}
         run: |
           flutter build "$BUILD_FORMAT" --release \
-            --flavor "$BUILD_FLAVOR" $BUILD_ARGS
+            --flavor "$BUILD_FLAVOR" $BUILD_ARGS \
+            --dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
+            --dart-define=SENTRY_RELEASE=mail-client-app@${{ github.ref_name }}+${{ github.run_number }}
 
       - name: Upload Android ${{ matrix.flavor }} ${{ matrix.format }} artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -655,7 +663,9 @@ jobs:
       - name: Compile iOS Runner.app (no codesign)
         run: |
           export PATH="$HOME/flutter/bin:$PATH"
-          flutter build ios --release --no-codesign
+          flutter build ios --release --no-codesign \
+            --dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
+            --dart-define=SENTRY_RELEASE=mail-client-app@${{ github.ref_name }}+${{ github.run_number }}
 
       - name: Package iOS .ipa from Runner.app
         run: |
@@ -765,7 +775,9 @@ jobs:
       - name: Compile macOS .app bundle (release)
         run: |
           export PATH="$HOME/flutter/bin:$PATH"
-          flutter build macos --release
+          flutter build macos --release \
+            --dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN }} \
+            --dart-define=SENTRY_RELEASE=mail-client-app@${{ github.ref_name }}+${{ github.run_number }}
 
       - name: Ad-hoc sign macOS app
         run: |
@@ -851,7 +863,10 @@ jobs:
         run: flutter pub get --enforce-lockfile
 
       - name: Compile Windows release binary
-        run: flutter build windows --release
+        run: |
+          flutter build windows --release `
+            --dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN }} `
+            --dart-define=SENTRY_RELEASE=mail-client-app@${{ github.ref_name }}+${{ github.run_number }}
 
       # SECURITY: Download VC++ Redistributable from Microsoft with pinned SHA-256.
       # Previously this binary was committed to the repo (windows/redist/vc_redist.x64.exe),


### PR DESCRIPTION
## Summary

- Adds `--dart-define=SENTRY_DSN=${{ secrets.SENTRY_DSN }}` + `--dart-define=SENTRY_RELEASE=mail-client-app@<tag>+<run>` to all 5 platform builds: Linux / Android / iOS / macOS / Windows.
- Linux: also installs `libcurl4-openssl-dev` — `sentry-native` (the desktop backend) links curl at compile time; without it CMake fails with `Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)`. Same fix that unblocked the mail-admin Linux build last week.
- Windows uses `pwsh` backtick (`` ` ``) line continuation; Linux/Android/iOS/macOS use bash `\`.

Pairs with #49 (`feat/sentry-crash-reporting` — SDK integration). Without this PR, shipped builds run with empty DSN → SDK init no-ops silent → defeats the SDK PR.

## Test plan

- [x] `SENTRY_DSN` secret set on repo (`2026-05-23T11:28:56Z`)
- [ ] Build CI passes on all 5 platforms with DSN injected (gitleaks scan + per-platform `flutter build`)
- [ ] After merge + tag release: signed APK/EXE/DMG/.deb/.ipa ship with active Sentry SDK
- [ ] First user-triggered event lands in Sentry project 3 (`mail-client-app`)

## Soft-fail design

If `secrets.SENTRY_DSN` were unset, `--dart-define` would inject empty string and SDK init no-ops (handled in `lib/main.dart`). First build after merge would not crash — just silently skip Sentry until secret is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)