### PR TITLE
fix(sentry): use --dart-define for DSN/release + ignore experimental warning

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -98,12 +98,30 @@ class _CrashErrorApp extends StatelessWidget {
 void main() async {
   await SentryFlutter.init(
     (options) {
-      options.dsn = 'https://4aa6338a8fb55197d7b2594ed6e24969@sentry-mail.icd360s.de/3';
+      // DSN injected at build time via --dart-define=SENTRY_DSN=...
+      // (see .github/workflows/build-all-platforms.yml). Default falls
+      // back to the project 3 DSN so local `flutter run` still sends
+      // to Sentry; rotate by updating the GitHub secret SENTRY_DSN.
+      options.dsn = const String.fromEnvironment(
+        'SENTRY_DSN',
+        defaultValue:
+            'https://4aa6338a8fb55197d7b2594ed6e24969@sentry-mail.icd360s.de/3',
+      );
+      // Release tag injected at build time via --dart-define=SENTRY_RELEASE=…
+      // Format: mail-client-app@{version}+{build}, kept in sync with pubspec
+      // by CI (build.yml uses ${{ github.ref_name }} + ${{ github.run_number }}).
+      // Dev fallback prevents Release Health from grouping ad-hoc runs with a
+      // real shipped version.
+      options.release = const String.fromEnvironment(
+        'SENTRY_RELEASE',
+        defaultValue: 'mail-client-app@dev',
+      );
       options.environment = kReleaseMode ? 'production' : 'development';
       options.tracesSampleRate = 0.1;
       options.sendDefaultPii = false;
       options.attachStacktrace = true;
       options.attachScreenshot = false;
+      // ignore: experimental_member_use
       options.attachViewHierarchy = false;
       options.enableAutoNativeBreadcrumbs = false;
       options.beforeSend = (event, hint) {


### PR DESCRIPTION
## Summary

Unblocks the v2.138.1 Build All Platforms run, which failed at flutter analyze on a warning-level lint:

warning - attachViewHierarchy is experimental and could be removed or changed at any time - lib/main.dart:107:15 - experimental_member_use

Three changes (all in lib/main.dart):

1. Suppress the experimental warning with // ignore: experimental_member_use. Disabling view-hierarchy capture is intentional (PII leakage from admin UI showing mail user emails); the API just happens to be experimental in sentry_flutter 9.x.

2. Switch options.dsn to String.fromEnvironment with the project 3 DSN as defaultValue. The --dart-define=SENTRY_DSN that PR #50 added to all 5 platform build steps was previously a no-op (DSN was hardcoded inline). Now CI uses the secret-injected DSN, local flutter run falls back to the same value.

3. Add options.release reading SENTRY_RELEASE the same way. Without it, Sentry was using SDK-detected version (often blank/wrong on desktop builds). Default mail-client-app@dev keeps ad-hoc runs out of real release buckets.

Matches the exact pattern from mail-admin/lib/main.dart, so behaviour is consistent across both Flutter apps pointing at the same self-hosted Sentry.

## Why v2.138.1 did not catch this

PR #49 added the Sentry code; PR #50 added the CI wire-up. Neither triggered Build All Platforms for the actual code paths (PR #49 failed at Resolve dependencies due to a lockfile race, PR #50 was a CI-only diff). v2.138.1 was the first run with both pubspec.lock synced AND the new workflow.

## Test plan

- [ ] CI: gitleaks pass + Build All Platforms run on this PR
- [ ] After merge: cocogitto auto-bumps to v2.138.2; tag push triggers Build All Platforms with --dart-define=SENTRY_DSN consumed
- [ ] Sentry server SQL check: events landing in sentry_groupedmessage for project_id=3 after first user opens v2.138.2

Co-authored by Claude Opus 4.7 (1M context)