### PR TITLE
fix(sentry): pre-bind Flutter engine to fix Windows startup hang

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -96,6 +96,16 @@ class _CrashErrorApp extends StatelessWidget {
 }
 
 void main() async {
+  // CRITICAL (Windows hang fix): bind to the Flutter engine via Sentry's
+  // wrapper BEFORE awaiting SentryFlutter.init. Without this, sentry-native
+  // can block startup indefinitely on Windows (no window ever shown,
+  // process sits idle with 20 threads in WaitForSingleObject) — observed
+  // 2026-05-24 with v2.138.2 on Windows Server 2025. Reproduced reliably:
+  // remove this line → install → run → 0 windows in 30s. With this line
+  // → window appears in ~1s. See sentry-dart#2491 — official workaround
+  // until sentry_flutter fixes the underlying race in their async init.
+  SentryWidgetsFlutterBinding.ensureInitialized();
+
   await SentryFlutter.init(
     (options) {
       // DSN injected at build time via --dart-define=SENTRY_DSN=...


### PR DESCRIPTION
## Summary

v2.138.2 regression: on Windows the app does not open. Process starts, 20 threads in WaitForSingleObject, ~0.3s CPU in 30s, sentry.dll never loads, crashpad_handler.exe never spawns, no window appears. Multiple launches stack as zombie PIDs.

## Root cause

await SentryFlutter.init is the first suspendable statement in main(). On Windows the SDK async setup races with the platform channel that has not been bound yet. The appRunner callback (which calls runApp) is never invoked.

## Fix

Bind the Flutter engine via Sentry wrapper BEFORE init. Sentry-official workaround for getsentry/sentry-dart issue 2491.

One line added before SentryFlutter.init:
   SentryWidgetsFlutterBinding.ensureInitialized();

## Verified locally (Windows Server 2025, v2.138.2 install)

Before fix: window 0 in 30s, no crashpad child, sentry.dll not loaded
After fix:  window at 0s, crashpad spawned as child PID, all plugins loaded

## Why CI did not catch this

CI runs flutter analyze and packages binaries; it never executes the .exe to confirm window appears. Smoke test could catch this; out of scope for this PR.

Co-authored by Claude Opus 4.7 (1M context)