### PR TITLE
fix(installer): bundle crashpad_handler.exe so Windows app actually opens

### DIFF
--- a/windows/installer.iss
+++ b/windows/installer.iss
@@ -53,6 +53,13 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 ; Main executable
 Source: "..\build\windows\x64\runner\Release\{#MyAppExeName}"; DestDir: "{app}"; Flags: ignoreversion
 
+; Sentry-native out-of-process crash handler. Without it, sentry-native
+; init hangs indefinitely on Windows (no window ever shown — observed in
+; v2.138.2 / v2.138.3 installs where the previous .iss glob excluded
+; secondary .exe files). The Dart-side SentryFlutter.init blocks waiting
+; for crashpad_handler.exe to be spawned next to the main executable.
+Source: "..\build\windows\x64\runner\Release\crashpad_handler.exe"; DestDir: "{app}"; Flags: ignoreversion
+
 ; Flutter engine and dependencies
 Source: "..\build\windows\x64\runner\Release\*.dll"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\build\windows\x64\runner\Release\data\*"; DestDir: "{app}\data"; Flags: ignoreversion recursesubdirs createallsubdirs


### PR DESCRIPTION
## Summary

v2.138.3 shipped PR #52 (Dart-side SentryWidgetsFlutterBinding fix) but installs still hang at startup. Window never appears, ~0.3s CPU in 30s, sentry.dll never loads.

## Root cause was the Inno Setup payload, not the Dart code

windows/installer.iss had:
   Source: Release\{main exe} ...   ← only main
   Source: Release\*.dll  ...        ← only dlls
   Source: Release\data\* ...        ← engine

flutter build windows --release produces TWO executables: the app AND crashpad_handler.exe (sentry-native out-of-process crash handler). The installer never picked up the second .exe, so installs were missing it. Without crashpad_handler.exe next to the main exe, sentry-native init blocks indefinitely on the spawn, appRunner never invoked, no window.

v2.138.2 installs accidentally had a stale crashpad_handler.exe left from prior manual installs, masking the bug. v2.138.3 installer cleanly wiped the install dir first, exposing it.

## Verified locally on Windows Server 2025

Against the v2.138.3 install:
- As-shipped (no crashpad_handler.exe): hangs forever, 4 zombie PIDs piled up
- After manual `Copy-Item crashpad_handler.exe ...` + relaunch: window in under 4s

After this PR is shipped, v2.138.4 installer will include crashpad_handler.exe and the auto-update path will recover for affected users.

## Why CI did not catch this

Inno Setup runs and produces the .exe without ever installing/launching it. CI never validates that the resulting binary actually opens a window — same gap exposed by PR #52.

Smoke test (post-install launch + 30s window check) is out of scope here but should be a follow-up.

Co-authored by Claude Opus 4.7 (1M context)