### PR TITLE
fix(plugins): commit regenerated registrants — fixes Windows startup hang

### DIFF
--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <openpgp/openpgp_plugin.h>
 #include <printing/printing_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 #include <window_manager/window_manager_plugin.h>
 
@@ -30,6 +31,9 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) screen_retriever_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "ScreenRetrieverLinuxPlugin");
   screen_retriever_linux_plugin_register_with_registrar(screen_retriever_linux_registrar);
+  g_autoptr(FlPluginRegistrar) sentry_flutter_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "SentryFlutterPlugin");
+  sentry_flutter_plugin_register_with_registrar(sentry_flutter_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -8,11 +8,13 @@ list(APPEND FLUTTER_PLUGIN_LIST
   openpgp
   printing
   screen_retriever_linux
+  sentry_flutter
   url_launcher_linux
   window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,8 +11,10 @@ import flutter_local_notifications
 import flutter_secure_storage_darwin
 import no_screenshot
 import openpgp
+import package_info_plus
 import printing
 import screen_retriever_macos
+import sentry_flutter
 import url_launcher_macos
 import window_manager
 
@@ -23,8 +25,10 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   MacOSNoScreenshotPlugin.register(with: registry.registrar(forPlugin: "MacOSNoScreenshotPlugin"))
   OpenpgpPlugin.register(with: registry.registrar(forPlugin: "OpenpgpPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))
   ScreenRetrieverMacosPlugin.register(with: registry.registrar(forPlugin: "ScreenRetrieverMacosPlugin"))
+  SentryFlutterPlugin.register(with: registry.registrar(forPlugin: "SentryFlutterPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   WindowManagerPlugin.register(with: registry.registrar(forPlugin: "WindowManagerPlugin"))
 }

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -12,6 +12,7 @@
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <printing/printing_plugin.h>
 #include <screen_retriever_windows/screen_retriever_windows_plugin_c_api.h>
+#include <sentry_flutter/sentry_flutter_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 #include <window_manager/window_manager_plugin.h>
 
@@ -28,6 +29,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("PrintingPlugin"));
   ScreenRetrieverWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ScreenRetrieverWindowsPluginCApi"));
+  SentryFlutterPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SentryFlutterPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
   WindowManagerPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -9,12 +9,14 @@ list(APPEND FLUTTER_PLUGIN_LIST
   permission_handler_windows
   printing
   screen_retriever_windows
+  sentry_flutter
   url_launcher_windows
   window_manager
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
   flutter_local_notifications_windows
+  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)


### PR DESCRIPTION
## Root cause of the v2.138.2 / .3 / .4 Windows hang saga

Three previous fixes (PR #52 SentryWidgetsFlutterBinding, PR #54 crashpad_handler.exe in installer) moved the needle but installs from clean v2.138.4 still hang forever — sentry.dll never loads, no window appears.

The actual problem is in COMMITTED generated plugin registrant files:

windows/flutter/generated_plugin_registrant.cc — missing
   include sentry_flutter/sentry_flutter_plugin.h
   SentryFlutterPluginRegisterWithRegistrar(...)
windows/flutter/generated_plugins.cmake        — missing sentry_flutter from FLUTTER_PLUGIN_LIST
linux/flutter/generated_plugin_registrant.cc   — same gap
linux/flutter/generated_plugins.cmake          — same
macos/Flutter/GeneratedPluginRegistrant.swift  — same

When sentry_flutter was added to pubspec, `flutter pub get` regenerates these locally. They were never committed. CI runs `flutter pub get --enforce-lockfile` which does NOT regenerate registrants, then `flutter build windows` uses the stale committed versions — built without sentry_flutter native registered.

Runtime effect: Dart `await SentryFlutter.init(...)` issues MethodChannel call to sentry_flutter. Dart side compiles fine (package in pubspec). Native side has no handler — channel exists but nothing listens. Future never completes, appRunner never invoked, no runApp, no window.

## Verified

- Local build (registrants regenerated by my pub get): opens in <4s
- CI build of v2.138.4 with crashpad in installer: hangs forever
- Diff between local working tree and committed: exactly the missing registration lines

## Why previous theories were wrong

PR #52 (SentryWidgetsFlutterBinding) seemed to work locally because LOCAL had regenerated registrants already; the binding change was incidental.
PR #54 (crashpad in installer) was a real bug too but only secondary — install with crashpad still hangs if platform channel handler is missing.

This is the real fix.

## Follow-up (separate PRs)

1. Either gitignore generated files (Flutter default) + ensure CI regenerates them, OR keep committed and pre-merge check they match `flutter pub get`
2. CI smoke test: launch built .exe post-install, wait 10s, verify window appears. Would have caught this on PR #52.

Co-authored by Claude Opus 4.7 (1M context)