### PR TITLE
fix(ci): bump Flutter 3.41.4 to 3.41.9 to fix Windows startup hang

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -32,7 +32,13 @@ permissions:
   contents: read
 
 env:
-  FLUTTER_VERSION: "3.41.4"
+  # Bumped 3.41.4 → 3.41.9 to fix Windows startup hang (v2.138.2..v2.138.5
+  # series). Reproduced empirically: same source code builds a non-hanging
+  # Windows .exe on Flutter 3.41.9 and a hanging one on 3.41.4. The
+  # difference is in flutter_windows.dll (engine) — likely a platform
+  # channel race in early init that 3.41.9 fixed. See PRs #52, #54, #55
+  # for false-lead theories before the version mismatch was identified.
+  FLUTTER_VERSION: "3.41.9"
   JAVA_VERSION: "17"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
## Actual root cause of v2.138.2..v2.138.5 Windows hang saga

Empirically reproduced on Windows Server 2025:
- Same v2.138.5 source built locally with Flutter 3.41.9: app opens in less than 1s
- Same source built on CI with Flutter 3.41.4: process hangs forever, no window, sentry.dll never loads, crashpad never spawns

Verified by overlaying local-build files onto the CI-installed binaries one by one until app started working.

The difference is in flutter_windows.dll (the engine binary shipped with each Flutter release). Bytes differ by 512 between 3.41.4 and 3.41.9. Likely a platform channel race in early init that was patched in 3.41.9 — sentry_flutter MethodChannel call from Dart-side init reaches the engine but never gets routed to the native plugin handler in 3.41.4.

## Previous fixes were partial or wrong-theory

- PR #52 SentryWidgetsFlutterBinding pre-bind: worked locally because my local Flutter is 3.41.9; the binding change itself is harmless but did not address the engine bug.
- PR #54 crashpad_handler.exe in installer: a real and separate bug, kept the fix.
- PR #55 regenerated plugin registrants: also real and separate, kept the fix.

This Flutter version bump is what actually unblocks the Windows binary.

## After merge

cocogitto bump to v2.138.6, CI rebuilds with Flutter 3.41.9, installs cleanly, opens.

Co-authored by Claude Opus 4.7 (1M context)