### PR TITLE
fix(ci): bump pinned Flutter SHA to 3.41.9 to unblock iOS+macOS+Deploy

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -619,7 +619,11 @@ jobs:
         run: |
           FLUTTER_ZIP="flutter_macos_${FL_VER}-stable.zip"
           FLUTTER_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/${FLUTTER_ZIP}"
-          EXPECTED_SHA="05fd35d2e4c29def0acb02e08e4faa6853115c3d9cf05c4e30c7e687b51f746d"
+          # Flutter 3.41.9 macOS x64 zip SHA-256. Update in lockstep with
+          # FLUTTER_VERSION above; otherwise iOS+macOS jobs fail at
+          # integrity check and Deploy to VPS gets skipped (broke v2.138.6).
+          # Fetch latest: curl .../releases_macos.json | jq for the SHA.
+          EXPECTED_SHA="eaee3b6aa6da114eb0be843ac53f4f138d3d8827779ff1e4546b345c75b9cba1"
           curl -fsSL -o "$FLUTTER_ZIP" "$FLUTTER_URL"
           ACTUAL_SHA=$(shasum -a 256 "$FLUTTER_ZIP" | cut -d' ' -f1)
           if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
@@ -723,7 +727,11 @@ jobs:
         run: |
           FLUTTER_ZIP="flutter_macos_${FL_VER}-stable.zip"
           FLUTTER_URL="https://storage.googleapis.com/flutter_infra_release/releases/stable/macos/${FLUTTER_ZIP}"
-          EXPECTED_SHA="05fd35d2e4c29def0acb02e08e4faa6853115c3d9cf05c4e30c7e687b51f746d"
+          # Flutter 3.41.9 macOS x64 zip SHA-256. Update in lockstep with
+          # FLUTTER_VERSION above; otherwise iOS+macOS jobs fail at
+          # integrity check and Deploy to VPS gets skipped (broke v2.138.6).
+          # Fetch latest: curl .../releases_macos.json | jq for the SHA.
+          EXPECTED_SHA="eaee3b6aa6da114eb0be843ac53f4f138d3d8827779ff1e4546b345c75b9cba1"
           curl -fsSL -o "$FLUTTER_ZIP" "$FLUTTER_URL"
           ACTUAL_SHA=$(shasum -a 256 "$FLUTTER_ZIP" | cut -d' ' -f1)
           if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then


### PR DESCRIPTION
## Why Android still hangs at Flutter splash logo

PR #56 bumped FLUTTER_VERSION 3.41.4 to 3.41.9 (fixes Windows hang). But the manual install steps for iOS and macOS pin the SHA-256 of the Flutter SDK zip in the workflow file. That pin was still set to 3.41.4 SHA, so iOS+macOS jobs fail at integrity check, Deploy to VPS skips (needs all platforms + !failure()), and the server version.json never advances past v2.138.5.

Android clients that auto-updated actually re-pull v2.138.5 (still Flutter 3.41.4) and hit the same engine bug as Windows: platform-channel race in early init blocks SentryFlutter.init forever, Flutter splash screen never advances.

## Fix

Update both EXPECTED_SHA values (lines 622, 726) to Flutter 3.41.9 macOS x64 archive SHA-256:
eaee3b6aa6da114eb0be843ac53f4f138d3d8827779ff1e4546b345c75b9cba1

Verified against the same source the install step pulls from: storage.googleapis.com/flutter_infra_release/releases/releases_macos.json

Added inline comment so next FLUTTER_VERSION bump remembers to move the SHA in lockstep.

## After merge

cocogitto bump to v2.138.7. All 5 platforms build clean. Deploy to VPS runs. Server version.json advances. Android auto-update pulls v2.138.7 APK with Flutter 3.41.9 engine. App opens past splash.

Co-authored by Claude Opus 4.7 (1M context)