### PR TITLE
fix(update): skip in-app updater when running under Flatpak

### DIFF
--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -211,6 +211,19 @@ class UpdateService {
 
   static Future<UpdateInfo?> _checkForUpdatesInternal() async {
     try {
+      // Flatpak sandbox: skip the in-app updater entirely.
+      // /.flatpak-info is injected into every Flatpak app at runtime
+      // (https://docs.flatpak.org/en/latest/sandbox-permissions.html).
+      // The in-app updater needs APPIMAGE env / writable system paths,
+      // neither of which exist in the sandbox — running it surfaces a
+      // misleading "Update failed" dialog. Updates for Flatpak users
+      // come via `flatpak update` / GNOME Software / Discover.
+      if (Platform.isLinux && File('/.flatpak-info').existsSync()) {
+        LoggerService.log('UPDATE',
+            'Running under Flatpak — skipping in-app updater (use `flatpak update`).');
+        return null;
+      }
+
       // Pin baseline to currentVersion on first run so any subsequent
       // proposal strictly below the currently installed build is rejected,
       // even before the first successful update bumps the baseline.


### PR DESCRIPTION
The Flatpak sandbox does not expose the APPIMAGE env var and forbids writes to system locations, so _installLinux() always fails and the user sees a misleading "Update failed" dialog the first time the app starts.

Detect /.flatpak-info (injected into every Flatpak app per docs.flatpak.org/en/latest/sandbox-permissions.html) and return null from _checkForUpdatesInternal so no UpdateInfo is surfaced. Flatpak users get updates via `flatpak update`, GNOME Software, or Discover — the same flow as for any other Flatpak app.

## Summary

<!-- What does this PR do? -->

## Changes

- 

## Checklist

- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `flutter analyze` passes with no issues
- [ ] Tested on at least one platform
- [ ] No sensitive data (keys, passwords, server details) in the code
- [ ] Updated CHANGELOG.md if user-facing change
