### PR TITLE
fix(update): broaden Flatpak detection with FLATPAK_ID env fallback

### DIFF
--- a/lib/services/update_service.dart
+++ b/lib/services/update_service.dart
@@ -212,13 +212,18 @@ class UpdateService {
   static Future<UpdateInfo?> _checkForUpdatesInternal() async {
     try {
       // Flatpak sandbox: skip the in-app updater entirely.
-      // /.flatpak-info is injected into every Flatpak app at runtime
-      // (https://docs.flatpak.org/en/latest/sandbox-permissions.html).
+      // Detect via /.flatpak-info (always injected per
+      // https://docs.flatpak.org/en/latest/sandbox-permissions.html) OR
+      // the FLATPAK_ID env var (set by the runtime for every app). Either
+      // signal is sufficient; checking both protects against edge cases
+      // where the file is unreadable due to a stricter portal policy.
       // The in-app updater needs APPIMAGE env / writable system paths,
       // neither of which exist in the sandbox — running it surfaces a
       // misleading "Update failed" dialog. Updates for Flatpak users
       // come via `flatpak update` / GNOME Software / Discover.
-      if (Platform.isLinux && File('/.flatpak-info').existsSync()) {
+      if (Platform.isLinux &&
+          (File('/.flatpak-info').existsSync() ||
+              Platform.environment.containsKey('FLATPAK_ID'))) {
         LoggerService.log('UPDATE',
             'Running under Flatpak — skipping in-app updater (use `flatpak update`).');
         return null;


### PR DESCRIPTION
The Flatpak guard in _checkForUpdatesInternal previously relied solely on /.flatpak-info. Add an OR check on the FLATPAK_ID environment variable (set by the runtime for every Flatpak app) so the guard still fires if a stricter portal policy or unusual filesystem override hides the file.

Either signal is sufficient — no false negatives are acceptable here since hitting the updater inside the sandbox surfaces a misleading "Update failed" dialog and (when combined with the libsecret init crash) contributed to the v2.139.1 Flatpak hang-and-disappear symptom.

## Summary

<!-- What does this PR do? -->

## Changes

- 

## Checklist

- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `flutter analyze` passes with no issues
- [ ] Tested on at least one platform
- [ ] No sensitive data (keys, passwords, server details) in the code
- [ ] Updated CHANGELOG.md if user-facing change
