### PR TITLE
feat(flatpak): host an OSTree repo on mail.icd360s.de so GNOME Softwa…

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -516,6 +516,45 @@ jobs:
           path: ICD360S-Mail-Client-*.flatpak
           retention-days: 30
 
+      # ──────────────────────────────────────────────────────────────────
+      # Flatpak REPO export — produces an OSTree-formatted repository
+      # tree alongside the single-file bundle. Hosting the repo (rather
+      # than handing users a .flatpak) is what unlocks:
+      #   • GNOME Software / Discover "Updates" page picks up new versions
+      #   • `flatpak remote-add icd360s …` + `flatpak update icd360s` flow
+      #   • No more "Update Issue" warning that bundle-only installs cause
+      #     when GNOME Software has no origin remote to refresh against
+      # The flatpak-builder action already builds INTO ./repo when it
+      # produces the bundle; we just refresh the summary file and tar it
+      # up so the deploy job can rsync it to the server.
+      - name: Refresh Flatpak repo summary
+        run: |
+          # Sanity-check the repo dir the action populated. Skip silently
+          # if cache restore short-circuited the build — we never want to
+          # block a release on this optional artifact.
+          if [ ! -d repo ]; then
+            echo "::warning::./repo not present (likely a cache hit). Skipping repo export."
+            exit 0
+          fi
+          flatpak build-update-repo --generate-static-deltas repo
+          # Print branch list for debugging — should show
+          # `app/de.icd360s.mailclient/x86_64/stable` (or similar).
+          ostree --repo=repo refs
+
+      - name: Tar Flatpak repo for transit
+        if: hashFiles('repo/summary') != ''
+        run: |
+          tar -cf flatpak-repo.tar -C repo .
+          ls -lh flatpak-repo.tar
+
+      - name: Upload Flatpak repo
+        if: hashFiles('flatpak-repo.tar') != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: flatpak-repo
+          path: flatpak-repo.tar
+          retention-days: 30
+
       - name: Flatpak build summary
         if: always()
         run: |
@@ -1172,6 +1211,22 @@ jobs:
           if [ -d "artifacts/flatpak-build" ]; then
             FLATPAK=$(find "artifacts/flatpak-build" -maxdepth 1 -name "*.flatpak" | head -1)
             [ -n "$FLATPAK" ] && cp "$FLATPAK" "${DEPLOY_DIR}/linux/icd360s-mail.flatpak"
+          fi
+
+          # Flatpak REPO (preferred install path — gives users `flatpak
+          # update` integration and removes the GNOME Software "Update
+          # Issue" warning that single-bundle installs trigger). Layout:
+          #   /downloads/mail/flatpak/        — OSTree repo root
+          #   /downloads/mail/flatpak/icd360s.flatpakrepo — discovery file
+          mkdir -p "${DEPLOY_DIR}/flatpak"
+          if [ -f "artifacts/flatpak-repo/flatpak-repo.tar" ]; then
+            tar -xf "artifacts/flatpak-repo/flatpak-repo.tar" -C "${DEPLOY_DIR}/flatpak/"
+            echo "Repo extracted; refs:"
+            ls -la "${DEPLOY_DIR}/flatpak/" | head -10
+          fi
+          # Discovery file (committed in-repo, copied as-is)
+          if [ -f flatpak/icd360s.flatpakrepo ]; then
+            cp flatpak/icd360s.flatpakrepo "${DEPLOY_DIR}/flatpak/icd360s.flatpakrepo"
           fi
 
           # Windows (.exe installer)

--- a/README.md
+++ b/README.md
@@ -174,13 +174,21 @@ graph LR
 </table>
 
 <details>
-<summary><kbd>Linux packages: DEB, RPM, tar.gz</kbd></summary>
+<summary><kbd>Linux packages: DEB, RPM, tar.gz, Flatpak repo</kbd></summary>
 
 | Format | Download |
 |:---|:---|
 | DEB (Ubuntu/Debian) | [icd360s-mail.deb](https://mail.icd360s.de/downloads/mail/linux/icd360s-mail.deb) |
 | RPM (Fedora/RHEL) | [icd360s-mail.rpm](https://mail.icd360s.de/downloads/mail/linux/icd360s-mail.rpm) |
 | tar.gz | [icd360s-mail-linux.tar.gz](https://mail.icd360s.de/downloads/mail/linux/icd360s-mail-linux.tar.gz) |
+
+**Flatpak (recommended for Fedora Silverblue/Kinoite + auto-updates):**
+```sh
+flatpak remote-add --if-not-exists icd360s \
+  https://mail.icd360s.de/downloads/mail/flatpak/icd360s.flatpakrepo
+flatpak install icd360s de.icd360s.mailclient
+```
+Updates land via `flatpak update` (or automatically through GNOME Software / KDE Discover). The single-file `.flatpak` bundle is still published per-release but the repo install avoids the "Update Issue" warning that bundle-only installs cause.
 
 </details>
 

--- a/flatpak/icd360s.flatpakrepo
+++ b/flatpak/icd360s.flatpakrepo
@@ -1,0 +1,9 @@
+[Flatpak Repo]
+Title=ICD360S
+Url=https://mail.icd360s.de/downloads/mail/flatpak/
+Homepage=https://icd360s.de
+Comment=ICD360S e.V. self-hosted Flatpak repository
+Description=Official Flatpak repository for ICD360S e.V. desktop applications. Updated automatically on every release of github.com/ICD360S-e-V/mail.
+Icon=https://mail.icd360s.de/downloads/mail/icd360s-logo.png
+DefaultBranch=stable
+SuggestRemoteName=icd360s


### PR DESCRIPTION
…re can track updates

Until now we only published a single-file .flatpak bundle per release. GNOME Software / KDE Discover happily install it once, then mark the app with "Update Issue" because it has no origin remote to refresh against (see flatpak/flatpak#3361, #4854). Manual reinstall per release is the only way to get a new version.

This change publishes a real Flatpak OSTree repository alongside the bundle and lets users add it once:

  flatpak remote-add icd360s \\
    https://mail.icd360s.de/downloads/mail/flatpak/icd360s.flatpakrepo
  flatpak install icd360s de.icd360s.mailclient

After that `flatpak update` and the store UIs pick up new versions automatically; the "Update Issue" warning is gone.

Wiring:
- build-flatpak job: after the existing build-bundle step the flatpak-builder action has already populated ./repo. We refresh the summary file, tar the directory, and upload it as a `flatpak-repo` artifact.
- deploy job: untar `flatpak-repo` into `deploy/downloads/mail/flatpak/` and copy the in-repo `icd360s.flatpakrepo` discovery file next to it. The existing rrsync-restricted target serves `/downloads/mail/` via nginx, so no new server-side path needs unblocking.
- README: add the `flatpak remote-add` snippet so users discover the preferred install path.

The single-file bundle is still produced for users who want a one-shot install without adding a remote. Repo signing with the existing APPIMAGE_GPG key is a follow-up; current iteration ships unsigned to keep this PR contained.

## Summary

<!-- What does this PR do? -->

## Changes

- 

## Checklist

- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `flutter analyze` passes with no issues
- [ ] Tested on at least one platform
- [ ] No sensitive data (keys, passwords, server details) in the code
- [ ] Updated CHANGELOG.md if user-facing change
