### PR TITLE
fix(flatpak): ship .flatpakrepo to the server and keep metainfo relea…

### DIFF
--- a/.github/workflows/build-all-platforms.yml
+++ b/.github/workflows/build-all-platforms.yml
@@ -547,12 +547,27 @@ jobs:
           tar -cf flatpak-repo.tar -C repo .
           ls -lh flatpak-repo.tar
 
+      - name: Stage Flatpak repo discovery file alongside artifact
+        # The .flatpakrepo discovery file lives in the source tree
+        # (flatpak/), but the deploy job has no `actions/checkout` —
+        # it only consumes artifacts. Copy it next to the tar so the
+        # artifact contains both. Without this, the file is missing
+        # on the server and nginx falls back to its default landing
+        # page when a user fetches `<repo>/icd360s.flatpakrepo`,
+        # which is what broke `flatpak remote-add` for v2.140.0.
+        if: hashFiles('flatpak/icd360s.flatpakrepo') != ''
+        run: |
+          cp flatpak/icd360s.flatpakrepo ./icd360s.flatpakrepo
+          ls -lh icd360s.flatpakrepo
+
       - name: Upload Flatpak repo
         if: hashFiles('flatpak-repo.tar') != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: flatpak-repo
-          path: flatpak-repo.tar
+          path: |
+            flatpak-repo.tar
+            icd360s.flatpakrepo
           retention-days: 30
 
       - name: Flatpak build summary
@@ -1224,9 +1239,11 @@ jobs:
             echo "Repo extracted; refs:"
             ls -la "${DEPLOY_DIR}/flatpak/" | head -10
           fi
-          # Discovery file (committed in-repo, copied as-is)
-          if [ -f flatpak/icd360s.flatpakrepo ]; then
-            cp flatpak/icd360s.flatpakrepo "${DEPLOY_DIR}/flatpak/icd360s.flatpakrepo"
+          # Discovery file — sourced from the same `flatpak-repo`
+          # artifact (the build-flatpak job stages it alongside the
+          # tar). No `actions/checkout` needed in this deploy job.
+          if [ -f "artifacts/flatpak-repo/icd360s.flatpakrepo" ]; then
+            cp "artifacts/flatpak-repo/icd360s.flatpakrepo" "${DEPLOY_DIR}/flatpak/icd360s.flatpakrepo"
           fi
 
           # Windows (.exe installer)

--- a/flatpak/de.icd360s.mailclient.metainfo.xml
+++ b/flatpak/de.icd360s.mailclient.metainfo.xml
@@ -48,6 +48,31 @@
   <content_rating type="oars-1.1" />
 
   <releases>
+    <release version="2.140.0" date="2026-05-31">
+      <description>
+        <p>Self-hosted Flatpak OSTree repository at mail.icd360s.de — users can now `flatpak remote-add icd360s` once and receive future updates through GNOME Software / Discover instead of the single-bundle install path.</p>
+      </description>
+    </release>
+    <release version="2.139.2" date="2026-05-28">
+      <description>
+        <p>Broaden Flatpak detection with FLATPAK_ID env var fallback so the in-app updater is suppressed even when /.flatpak-info is unreadable under stricter portal policies.</p>
+      </description>
+    </release>
+    <release version="2.139.1" date="2026-05-28">
+      <description>
+        <p>Flatpak release: bundle libsecret-1, drop the unused Background portal claim, and skip the in-app updater when running inside the Flatpak sandbox. Fixes the "Update failed" + spinner-disappears symptom.</p>
+      </description>
+    </release>
+    <release version="2.139.0" date="2026-05-28">
+      <description>
+        <p>Initial Flatpak bundle + raw tar.gz support for Fedora Silverblue / Kinoite toolbox installs.</p>
+      </description>
+    </release>
+    <release version="2.138.8" date="2026-05-27">
+      <description>
+        <p>Sentry init hardening: disable native crash handling on Android and add a 10-second timeout so a stuck SDK init can never block app startup.</p>
+      </description>
+    </release>
     <release version="2.138.7" date="2026-05-26">
       <description>
         <p>Sentry crash monitoring shipped to production. Windows startup fix series resolved.</p>

--- a/scripts/update-pubspec-version.sh
+++ b/scripts/update-pubspec-version.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 #   1. pubspec.yaml  → version: X.Y.Z+BUILD
 #   2. pubspec.yaml  → msix_version: X.Y.Z.BUILD
 #   3. update_service.dart → currentVersion = 'X.Y.Z'
+#   4. flatpak/de.icd360s.mailclient.metainfo.xml → prepend <release>.
+#      Without this the AppStream `<releases>` block lags behind the
+#      pubspec version, so GNOME Software / KDE Discover think the
+#      latest available version is whatever was last listed there —
+#      which is what caused the "Update Issue" / "the file detects
+#      2.138.7" symptom on 2.140.0 installs.
 
 NEW_VERSION="$1"
 
@@ -25,4 +31,33 @@ sed -i "s/^  msix_version: .*/  msix_version: ${MAJOR}.${MINOR}.${PATCH}.${BUILD
 # 3. update_service.dart hardcoded currentVersion
 sed -i "s/static const String currentVersion = '.*'/static const String currentVersion = '${NEW_VERSION}'/" lib/services/update_service.dart
 
-echo "Updated: version ${NEW_VERSION}+${BUILD_NUMBER}, msix ${MAJOR}.${MINOR}.${PATCH}.${BUILD_NUMBER}, currentVersion '${NEW_VERSION}'"
+# 4. flatpak/de.icd360s.mailclient.metainfo.xml — prepend a new <release>
+# block under <releases> with today's date. Skipped if the version is
+# already declared (idempotent — safe to re-run).
+METAINFO="flatpak/de.icd360s.mailclient.metainfo.xml"
+TODAY=$(date -u +%Y-%m-%d)
+if [ -f "$METAINFO" ] && ! grep -q "version=\"${NEW_VERSION}\"" "$METAINFO"; then
+  # Use a Python heredoc instead of sed — preserves indentation and
+  # avoids sed-quoting hell on the multi-line replacement.
+  python3 - "$METAINFO" "$NEW_VERSION" "$TODAY" <<'PYEOF'
+import sys, re
+path, version, date = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, 'r', encoding='utf-8') as f:
+    xml = f.read()
+new_release = (
+    f'    <release version="{version}" date="{date}">\n'
+    f'      <description>\n'
+    f'        <p>Maintenance release. See the GitHub release notes for details.</p>\n'
+    f'      </description>\n'
+    f'    </release>\n'
+)
+xml2 = re.sub(r'(<releases>\s*\n)', r'\g<1>' + new_release, xml, count=1)
+if xml2 == xml:
+    sys.stderr.write(f'WARN: could not find <releases> opening tag in {path}\n')
+else:
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(xml2)
+PYEOF
+fi
+
+echo "Updated: version ${NEW_VERSION}+${BUILD_NUMBER}, msix ${MAJOR}.${MINOR}.${PATCH}.${BUILD_NUMBER}, currentVersion '${NEW_VERSION}', metainfo release ${NEW_VERSION}"


### PR DESCRIPTION
…ses in sync

Two follow-ups to the v2.140.0 repo-hosting rollout, both reported by a user trying to add the repo and seeing GNOME Software still report the app as 2.138.7:

1. .flatpakrepo discovery file never reached the server. The build job wrote it from the source tree (`flatpak/icd360s.flatpakrepo`), but the deploy job has no `actions/checkout` step — it only consumes artifacts — so `if [ -f flatpak/icd360s.flatpakrepo ]` was always false, the file was never copied, and nginx fell back to the default landing page when a user fetched <repo>/icd360s.flatpakrepo. Fix: copy the file alongside the tar in the `flatpak-repo` artifact and read it from there in deploy.

2. metainfo.xml `<releases>` block was frozen at 2.138.7. AppStream pulls this into GNOME Software / KDE Discover, so the store kept showing "latest available: 2.138.7" even after 2.140.0 landed — which surfaces as the "Update Issue" warning the user reported and as the file showing 2.138.7 inside the Flatpak store. Backfill the missing entries (2.138.8, 2.139.0, 2.139.1, 2.139.2, 2.140.0) and extend `scripts/update-pubspec-version.sh` so cocogitto's `pre_bump_hooks` also prepends a `<release>` entry on every future bump (idempotent: skips if the version is already declared).

`appstreamcli validate` passes on the updated metainfo.

## Summary

<!-- What does this PR do? -->

## Changes

- 

## Checklist

- [ ] Follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] `flutter analyze` passes with no issues
- [ ] Tested on at least one platform
- [ ] No sensitive data (keys, passwords, server details) in the code
- [ ] Updated CHANGELOG.md if user-facing change
